### PR TITLE
Fix import of classnames

### DIFF
--- a/frontend/src/components/OdhAppCard.tsx
+++ b/frontend/src/components/OdhAppCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as classNames from 'ClassNames';
+import * as classNames from 'classnames';
 import {
   Brand,
   Card,

--- a/frontend/src/components/OdhExploreCard.tsx
+++ b/frontend/src/components/OdhExploreCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as classNames from 'ClassNames';
+import * as classNames from 'classnames';
 import { Brand, Card, CardHeader, CardTitle, CardBody } from '@patternfly/react-core';
 import { ODHAppType } from '../types';
 


### PR DESCRIPTION
Import of classnames as `ClassNames` works on mac, but not in the s2i builds.