### PR TITLE
Use standard user icon for user until we can get the real username. Fix html title.

### DIFF
--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -12,6 +12,10 @@ html, body, #root {
     white-space: pre-wrap;
   }
 
+  &__user-icon {
+    font-size: var(--pf-global--FontSize--xl);
+  }
+
   // PF Overrides
   .pf-c-page__header {
     .pf-c-brand {

--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -1,20 +1,16 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   Dropdown,
+  DropdownPosition,
   DropdownToggle,
   PageHeaderTools,
   PageHeaderToolsGroup,
   PageHeaderToolsItem,
   DropdownItem,
 } from '@patternfly/react-core';
-import { CaretDownIcon } from '@patternfly/react-icons';
+import { CaretDownIcon, UserIcon } from '@patternfly/react-icons';
 
-type HeaderToolsProps = {
-  user: { name: string; token: string };
-};
-
-const HeaderTools: React.FC<HeaderToolsProps> = ({ user }) => {
+const HeaderTools: React.FC = () => {
   const [userMenuOpen, setUserMenuOpen] = React.useState<boolean>(false);
 
   const handleLogout = () => {
@@ -30,22 +26,20 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ user }) => {
       Log out
     </DropdownItem>,
   ];
-  const userName = React.useMemo(() => {
-    return user?.name?.split('/')?.[0];
-  }, [user]);
 
   return (
     <PageHeaderTools>
       <PageHeaderToolsGroup className="hidden-xs">
         <PageHeaderToolsItem>
           <Dropdown
+            position={DropdownPosition.right}
             toggle={
               <DropdownToggle
                 id="toggle-id"
                 onToggle={() => setUserMenuOpen(!userMenuOpen)}
                 toggleIndicator={CaretDownIcon}
               >
-                {userName}
+                <UserIcon className="odh-dashboard__user-icon" />
               </DropdownToggle>
             }
             isOpen={userMenuOpen}
@@ -57,8 +51,4 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ user }) => {
   );
 };
 
-const mapStateToProps = (state) => ({
-  user: state.appReducer.user,
-});
-
-export default connect(mapStateToProps)(HeaderTools);
+export default HeaderTools;

--- a/frontend/src/images/odh-logo.svg
+++ b/frontend/src/images/odh-logo.svg
@@ -58,7 +58,7 @@
        id="g2897"
        transform="matrix(4.0724844,0,0,4.0724844,-430.01386,195.33008)">
       <g
-         aria-label="OPEN DATA HUB"
+         aria-label="Red Hat OpenShift Data Science"
          style="font-style:normal;font-weight:normal;font-size:1.26598549px;line-height:0.79124087px;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#818284;fill-opacity:1;stroke:none;stroke-width:0.00771748px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          id="text2891">
         <path

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#ffffff" />
     <link rel="shortcut icon" href="images/favicon.svg">
-    <title>Open Data Hub Dashboard</title>
+    <title>Red Hat OpenShift Data Science Dashboard</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHODS-501
Addresses https://issues.redhat.com/browse/RHODS-495

Uses an icon rather than text for the current user making it better by not showing `inClusterUser`.

![image](https://user-images.githubusercontent.com/11633780/114445892-990f8000-9b9e-11eb-8a4c-71d403302ad6.png)

/cc @kywalker-rh 
