### PR TITLE
Periodically fetch CSVs and Services and cache results

### DIFF
--- a/backend/plugins/kube.js
+++ b/backend/plugins/kube.js
@@ -4,6 +4,8 @@ const { DEV_MODE } = require('../utils/constants');
 const fs = require('fs');
 const fp = require('fastify-plugin');
 const k8s = require('@kubernetes/client-node');
+const WatchInstalledOperators = require('../utils/watchInstalledOperators');
+const WatchServices = require('../utils/watchServices');
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
@@ -33,6 +35,10 @@ module.exports = fp(async (fastify) => {
     customObjectsApi,
     currentUser,
   });
+
+  // TODO: Watch only when a UI connects
+  WatchInstalledOperators.startWatching(customObjectsApi);
+  WatchServices.startWatching(coreV1Api);
 });
 
 const getCurrentNamespace = async () => {

--- a/backend/routes/api/components/list.js
+++ b/backend/routes/api/components/list.js
@@ -1,3 +1,5 @@
+const WatchInstalledOperators = require('../../../utils/watchInstalledOperators');
+const WatchServices = require('../../../utils/watchServices');
 const componentUtils = require('./componentUtils');
 
 module.exports = async ({ fastify, request }) => {
@@ -6,8 +8,8 @@ module.exports = async ({ fastify, request }) => {
   // Fetch the installed kfDefs
   const kfdefApps = await componentUtils.getInstalledKfdefs(fastify);
 
-  // Fetch the installed kfDefs
-  const operatorCSVs = await componentUtils.getInstalledOperators(fastify);
+  const operatorCSVs = WatchInstalledOperators.getInstalledOperators();
+  const services = WatchServices.getServices();
 
   // Fetch the enabled config maps
   const enabledCMs = await componentUtils.getEnabledConfigMaps(fastify, applicationDefs);
@@ -47,11 +49,6 @@ module.exports = async ({ fastify, request }) => {
     }
     return acc;
   }, []);
-
-  let services = [];
-  if (installedComponents.find((comp) => comp.spec.serviceName)) {
-    services = await componentUtils.getServices(fastify);
-  }
 
   await Promise.all(
     installedComponents.map(async (installedComponent) => {

--- a/backend/utils/watchInstalledOperators.js
+++ b/backend/utils/watchInstalledOperators.js
@@ -1,0 +1,56 @@
+const WATCH_INTERVAL = 2 * 60 * 1000;
+
+let watchTimer = null;
+let installedOperators = [];
+
+const fetchInstalledOperators = (customObjectsApi) => {
+  return customObjectsApi
+    .listNamespacedCustomObject('operators.coreos.com', 'v1alpha1', '', 'clusterserviceversions')
+    .then((res) => {
+      const csvs = res?.body?.items;
+      if (csvs?.length) {
+        return csvs.reduce((acc, csv) => {
+          if (csv.status?.phase === 'Succeeded' && csv.status?.reason === 'InstallSucceeded') {
+            acc.push(csv);
+          }
+          return acc;
+        }, []);
+      }
+      return [];
+    })
+    .catch((e) => {
+      console.error(e, 'failed to get ClusterServiceVersions');
+      return [];
+    });
+};
+
+const startWatching = (customObjectsApi) => {
+  if (watchTimer !== null) {
+    return;
+  }
+
+  // no timer, but non-null
+  watchTimer = 0;
+  fetchInstalledOperators(customObjectsApi).then((results) => {
+    installedOperators = results;
+    watchTimer = setInterval(() => {
+      if (watchTimer) {
+        fetchInstalledOperators(customObjectsApi).then((results) => {
+          installedOperators = results;
+        });
+      }
+    }, WATCH_INTERVAL);
+  });
+};
+
+const stopWatching = () => {
+  if (!watchTimer) {
+    return;
+  }
+  clearInterval(watchTimer);
+  watchTimer = null;
+};
+
+const getInstalledOperators = () => installedOperators;
+
+module.exports = { startWatching, getInstalledOperators, stopWatching };

--- a/backend/utils/watchServices.js
+++ b/backend/utils/watchServices.js
@@ -1,0 +1,47 @@
+const WATCH_INTERVAL = 2 * 60 * 1000;
+
+let watchTimer = null;
+let services = [];
+
+const fetchServices = (coreV1Api) => {
+  return coreV1Api
+    .listServiceForAllNamespaces()
+    .then((res) => {
+      return res?.body?.items;
+    })
+    .catch((e) => {
+      console.error(e, 'failed to get Services');
+      return [];
+    });
+};
+
+const startWatching = (customObjectsApi) => {
+  if (watchTimer !== null) {
+    return;
+  }
+
+  // no timer, but non-null
+  watchTimer = 0;
+  fetchServices(customObjectsApi).then((results) => {
+    services = results;
+    watchTimer = setInterval(() => {
+      if (watchTimer) {
+        fetchServices(customObjectsApi).then((results) => {
+          services = results;
+        });
+      }
+    }, WATCH_INTERVAL);
+  });
+};
+
+const stopWatching = () => {
+  if (!watchTimer) {
+    return;
+  }
+  clearInterval(watchTimer);
+  watchTimer = null;
+};
+
+const getServices = () => services;
+
+module.exports = { startWatching, getServices, stopWatching };


### PR DESCRIPTION
At startup, start fetching CSVs and Services every 2 minutes.
Cache these results and use them on queries rather than fetching them at query time (can be slow on large systems).