### PR TITLE
Fix python-accelerated typo

### DIFF
--- a/data/docs/python-acceleration-numba-tutorial.yaml
+++ b/data/docs/python-acceleration-numba-tutorial.yaml
@@ -5,6 +5,6 @@ spec:
   appName: anaconda-ce
   displayName: Accelerating Scientific Workloads in Python with Numba
   description: |-
-    If you're interesting making your Python code run faster, this talk is for you
+    If you're interested in making your Python code run faster, this talk is for you.
   url: https://www.youtube.com/watch?v=6oXedk2tGfk
   durationMinutes: 42


### PR DESCRIPTION
This change fixes a typo in the description for the
python-accelerated-numba-tutorial tutorial widget.