### PR TITLE
Fixed typos in resources description

### DIFF
--- a/data/applications/starburst.yaml
+++ b/data/applications/starburst.yaml
@@ -4,7 +4,7 @@ spec:
   displayName: Starburst Galaxy
   provider: Starburst
   description: |-
-    Starburst Galaxy is a fully-managed service to run high performance queries across your various data sources using SQL
+    Starburst Galaxy is a fully-managed service to run high performance queries across your various data sources using SQL.
   kfdefApplications: []
   route: ''
   img: images/starburst.svg

--- a/data/docs/jupyter-notebooks-in-watson-studio-tutorial.yaml
+++ b/data/docs/jupyter-notebooks-in-watson-studio-tutorial.yaml
@@ -5,6 +5,6 @@ spec:
   appName: watson-studio
   displayName: Jupyter Notebooks in Watson Studio
   description: |-
-    This video covers the basics for working with Jupyter notebooks in Watson Studio
+    This video covers the basics for working with Jupyter notebooks in Watson Studio.
   url: https://video.ibm.com/channel/23952663/video/cpd35-ws-notebook-basics
   durationMinutes: 3

--- a/data/docs/seldon-model-servings-tutorial.yaml
+++ b/data/docs/seldon-model-servings-tutorial.yaml
@@ -6,6 +6,6 @@ spec:
   displayName: Various types of Model Servings
   description: |-
     A series of tutorials highlighting natural language, image processing classifiers, KubeFlow
-    integration, and model
+    integration, and model.
   url: https://deploy.seldon.io/docs/demos/seldon-core/
   durationMinutes: 60

--- a/data/docs/watson-studio-cleanse-shape-visualize-how-to.yaml
+++ b/data/docs/watson-studio-cleanse-shape-visualize-how-to.yaml
@@ -5,6 +5,6 @@ spec:
   appName: watson-studio
   displayName: How to cleanse, shape, and visualize my data?
   description: |-
-    Using data refinery to cleanse and shape tabular data
+    Using data refinery to cleanse and shape tabular data.
   url: https://www.ibm.com/support/knowledgecenter/SSQNUZ_3.5.0/wsj/refinery/refining_data.html
   durationMinutes: 10

--- a/data/docs/watson-studio-create-deployment-space-how-to.yaml
+++ b/data/docs/watson-studio-create-deployment-space-how-to.yaml
@@ -5,6 +5,6 @@ spec:
   appName: watson-studio
   displayName: How to create a deployment space for deploying my model?
   description: |-
-    Steps to create a deployment space
+    Steps to create a deployment space.
   url: https://www.ibm.com/support/knowledgecenter/SSQNUZ_3.5.0/wsj/analyze-data/ml-spaces_local.html
   durationMinutes: 10

--- a/data/docs/watson-studio-integrate-with-github-how-to.yaml
+++ b/data/docs/watson-studio-integrate-with-github-how-to.yaml
@@ -5,6 +5,6 @@ spec:
   appName: watson-studio
   displayName: How to create a project that's integrated with Github?
   description: |-
-    How to add assets in the Git repository in a project
+    How to add assets in the Git repository in a project.
   url: https://www.ibm.com/support/knowledgecenter/SSQNUZ_3.5.0/wsj/manage-data/git-integration.html
   durationMinutes: 10

--- a/data/docs/watson-studio-load-data-how-to.yaml
+++ b/data/docs/watson-studio-load-data-how-to.yaml
@@ -5,6 +5,6 @@ spec:
   appName: watson-studio
   displayName: How to load data into Notebook?
   description: |-
-    How to integrate data sources into a notebook
+    How to integrate data sources into a notebook.
   url: https://www.ibm.com/support/knowledgecenter/SSQNUZ_3.5.0/wsj/analyze-data/load-and-access-data.html
   durationMinutes: 5

--- a/data/docs/watson-studio-runtime-env-how-to.yaml
+++ b/data/docs/watson-studio-runtime-env-how-to.yaml
@@ -5,6 +5,6 @@ spec:
   appName: watson-studio
   displayName: What are my choices for notebook runtime environments?
   description: |-
-    How to configure a notebook runtime environment
+    How to configure a notebook runtime environment.
   url: https://www.ibm.com/support/knowledgecenter/SSQNUZ_3.5.0/wsj/analyze-data/notebook-environments.html
   durationMinutes: 5

--- a/data/docs/watson-studio-setup-openscale-how-to.yaml
+++ b/data/docs/watson-studio-setup-openscale-how-to.yaml
@@ -5,6 +5,6 @@ spec:
   appName: watson-studio
   displayName: How to set up Watson OpenScale?
   description: |-
-    Track and measure outcomes from models with OpenScale
+    Track and measure outcomes from models with OpenScale.
   url: https://www.ibm.com/support/knowledgecenter/SSQNUZ_3.5.0/wsj/model/getting-started.html
   durationMinutes: 10

--- a/data/quickstarts/connect-rhosak-notebook-quickstart.yaml
+++ b/data/quickstarts/connect-rhosak-notebook-quickstart.yaml
@@ -5,7 +5,7 @@ spec:
   displayName: Connecting to Red Hat OpenShift Streams for Apache Kafka
   durationMinutes: 10
   icon: 'images/red-hat.svg'
-  description: This quick start will walk you through connecting to Red Hat Streams for Apache Kafka using Jupyter Notebooks
+  description: This quick start will walk you through connecting to Red Hat Streams for Apache Kafka using Jupyter Notebooks.
   introduction: |-
     ### This quick start shows you how to connect to Streams for Apache Kafka from a Jupyter notebook.
     Welcome to the Red Hat OpenShift Streams for Apache Kafka quick start

--- a/data/quickstarts/deploy-python-model-quickstart.yaml
+++ b/data/quickstarts/deploy-python-model-quickstart.yaml
@@ -2,10 +2,10 @@ kind: ConsoleQuickStart
 metadata:
   name: deploy-python-model
 spec:
-  displayName: Deploying a sample Python application using Flask and OpenShift
+  displayName: Deploying a sample Python application using Flask and OpenShift.
   durationMinutes: 10
   icon: 'images/jupyterhub.svg'
-  description: How to deploy a Python model using Flask and OpenShift
+  description: How to deploy a Python model using Flask and OpenShift.
   prerequisites: [You completed the "Create a Jupyter notebook" quick start.]
   introduction: |-
     ### This quick start shows you how to deploy a Python Model.

--- a/data/quickstarts/seldon-deploy-canary-quickstart.yaml
+++ b/data/quickstarts/seldon-deploy-canary-quickstart.yaml
@@ -5,7 +5,7 @@ spec:
   displayName: Launch a SKLearn model and update model by canarying
   durationMinutes: 10
   icon: 'images/seldon.svg'
-  description: How to perform a canary promotion of a Scikit-Learn model
+  description: How to perform a canary promotion of a Scikit-Learn model.
   prerequisites: [You completed the "Create a Jupyter notebook" quick start.]
   introduction: |-
     ### This quick start shows you how to launch a SKLearn model and update model by canarying.

--- a/data/quickstarts/seldon-deploy-drift-quickstart.yaml
+++ b/data/quickstarts/seldon-deploy-drift-quickstart.yaml
@@ -5,7 +5,7 @@ spec:
   displayName: Monitor drift for deployed model
   durationMinutes: 10
   icon: 'images/seldon.svg'
-  description: Monitor drift for deployed image classifier model
+  description: Monitor drift for deployed image classifier model.
   introduction: |-
     ### This quick start shows you how to launch a tensorflow image classifier model and detect when requests to the model are drifting.
     Seldon Deploy is a specialist set of tools designed to simplify and accelerate the process of deploying and managing your machine learning models.

--- a/data/quickstarts/seldon-deploy-explainer-quickstart.yaml
+++ b/data/quickstarts/seldon-deploy-explainer-quickstart.yaml
@@ -5,7 +5,7 @@ spec:
   displayName: See predictions and explanations for a deployed SKLearn model
   durationMinutes: 10
   icon: 'images/seldon.svg'
-  description: See predictions and explanations for deployed income classifier model
+  description: See predictions and explanations for deployed income classifier model.
   introduction: |-
     ### This quick start shows you how to launch an income classifier model and see explanations.
     Seldon Deploy is a specialist set of tools designed to simplify and accelerate the process of deploying and managing your machine learning models.

--- a/data/quickstarts/seldon-deploy-outlier-quickstart.yaml
+++ b/data/quickstarts/seldon-deploy-outlier-quickstart.yaml
@@ -5,7 +5,7 @@ spec:
   displayName: See outlier scores for predictions to deployed model
   durationMinutes: 10
   icon: 'images/seldon.svg'
-  description: See outlier scores for predictions to a deployed image classifier model
+  description: See outlier scores for predictions to a deployed image classifier model.
   introduction: |-
     ### This quick start shows you how to launch a tensorflow image classifier model and detect requests which are outliers.
     Seldon Deploy is a specialist set of tools designed to simplify and accelerate the process of deploying and managing your machine learning models.


### PR DESCRIPTION
**Changes proposed in this pull request**
- 
- Fixing typos in the Resources widgest.

**Test instructions**
 1. I've updated the description in /data/applications, so all the phrases end up in period.

**Closing issues**
1. Closes [RHODS-744](https://issues.redhat.com/browse/RHODS-744)

**Additional context**
1. It's my first PR, so I'm not sure if this is the proper way to open a change, please tell me the best practices to work with this project.
