### PR TITLE
Get real username when in cluster

### DIFF
--- a/backend/src/routes/api/status/index.ts
+++ b/backend/src/routes/api/status/index.ts
@@ -31,7 +31,7 @@ export default async (fastify: FastifyInstance): Promise<void> => {
     return status(fastify)
       .then((res) => {
         if (request.headers['x-forwarded-user']) {
-          res.kube.currentUser = request.headers['x-forwarded-user'];
+          (res.kube.currentUser as any) = request.headers['x-forwarded-user'];
         }
         if (DEV_MODE) {
           addCORSHeader(request, reply);

--- a/backend/src/routes/api/status/index.ts
+++ b/backend/src/routes/api/status/index.ts
@@ -1,12 +1,13 @@
 import createError from 'http-errors';
-import { FastifyInstance } from 'fastify';
+import { FastifyInstance, FastifyRequest } from 'fastify';
 import { KubeFastifyInstance, KubeStatus } from '../../../types';
 import { DEV_MODE } from '../../../utils/constants';
 import { addCORSHeader } from '../../../utils/responseUtils';
 
-const status = async (fastify: KubeFastifyInstance): Promise<{ kube: KubeStatus }> => {
+const status = async (fastify: KubeFastifyInstance, request: FastifyRequest): Promise<{ kube: KubeStatus }> => {
   const kubeContext = fastify.kube.currentContext;
   const { currentContext, namespace, currentUser } = fastify.kube;
+  const userName = request.headers['x-forwarded-user'] ?? currentUser.username;
   if (!kubeContext && !kubeContext.trim()) {
     const error = createError(500, 'failed to get kube status');
     error.explicitInternalServerError = true;
@@ -21,6 +22,7 @@ const status = async (fastify: KubeFastifyInstance): Promise<{ kube: KubeStatus 
         currentContext,
         currentUser,
         namespace,
+        userName,
       },
     });
   }
@@ -28,11 +30,8 @@ const status = async (fastify: KubeFastifyInstance): Promise<{ kube: KubeStatus 
 
 export default async (fastify: FastifyInstance): Promise<void> => {
   fastify.get('/', async (request, reply) => {
-    return status(fastify)
+    return status(fastify, request)
       .then((res) => {
-        if (request.headers['x-forwarded-user']) {
-          (res.kube.currentUser as any) = request.headers['x-forwarded-user'];
-        }
         if (DEV_MODE) {
           addCORSHeader(request, reply);
         }

--- a/backend/src/routes/api/status/index.ts
+++ b/backend/src/routes/api/status/index.ts
@@ -4,7 +4,10 @@ import { KubeFastifyInstance, KubeStatus } from '../../../types';
 import { DEV_MODE } from '../../../utils/constants';
 import { addCORSHeader } from '../../../utils/responseUtils';
 
-const status = async (fastify: KubeFastifyInstance, request: FastifyRequest): Promise<{ kube: KubeStatus }> => {
+const status = async (
+  fastify: KubeFastifyInstance,
+  request: FastifyRequest,
+): Promise<{ kube: KubeStatus }> => {
   const kubeContext = fastify.kube.currentContext;
   const { currentContext, namespace, currentUser } = fastify.kube;
   const userName = request.headers['x-forwarded-user'] ?? currentUser.username;

--- a/backend/src/routes/api/status/index.ts
+++ b/backend/src/routes/api/status/index.ts
@@ -30,6 +30,9 @@ export default async (fastify: FastifyInstance): Promise<void> => {
   fastify.get('/', async (request, reply) => {
     return status(fastify)
       .then((res) => {
+        if (request.headers['x-forwarded-user']) {
+          res.kube.currentUser = request.headers['x-forwarded-user'];
+        }
         if (DEV_MODE) {
           addCORSHeader(request, reply);
         }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -68,6 +68,7 @@ export type KubeStatus = {
   currentContext: string;
   currentUser: User;
   namespace: string;
+  userName: string | string[];
 };
 
 export type KubeDecorator = KubeStatus & {


### PR DESCRIPTION
Since we use [OpenShift oauth-proxy](https://github.com/openshift/oauth-proxy#command-line-options) when the application is in a cluster, we can read the username directly from the headers `x-forwarded-user` field of the request that proxy transmits to the server.
This PR changes the `status` API to read the username and send it back to the front-end.