### PR TITLE
Add resources filter by provider type

### DIFF
--- a/frontend/src/pages/learningCenter/LearningCenter.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenter.tsx
@@ -99,6 +99,7 @@ const LearningCenter: React.FC = () => {
             updatedDoc.spec.img = odhDoc.spec.img || odhApp.spec.img;
             updatedDoc.spec.description = odhDoc.spec.description || odhApp.spec.description;
             updatedDoc.spec.provider = odhDoc.spec.provider || odhApp.spec.provider;
+            updatedDoc.spec.appCategory = odhDoc.spec.appCategory || odhApp.spec.category;
           } else {
             updatedDoc.spec.appEnabled = false;
           }

--- a/frontend/src/pages/learningCenter/LearningCenterFilters.tsx
+++ b/frontend/src/pages/learningCenter/LearningCenterFilters.tsx
@@ -10,6 +10,7 @@ import EnabledFilters from './EnabledFilters';
 import DocTypeFilters from './DocTypeFilters';
 import { CATEGORY_FILTER_KEY } from './const';
 import ApplicationFilters from './ApplicationFilters';
+import ProviderTypeFilters from './ProviderTypeFilters';
 
 type LearningCenterFilterProps = {
   docApps: OdhDocument[];
@@ -47,6 +48,7 @@ const LearningCenterFilters: React.FC<LearningCenterFilterProps> = ({
       <EnabledFilters categoryApps={categoryApps} />
       <DocTypeFilters categoryApps={categoryApps} />
       <ApplicationFilters docApps={docApps} categoryApps={categoryApps} />
+      <ProviderTypeFilters docApps={docApps} categoryApps={categoryApps} />
     </div>
   );
 };

--- a/frontend/src/pages/learningCenter/ProviderTypeFilters.tsx
+++ b/frontend/src/pages/learningCenter/ProviderTypeFilters.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { useHistory } from 'react-router';
+import { OdhDocument } from '../../types';
+import {
+  FilterSidePanelCategory,
+  FilterSidePanelCategoryItem,
+} from '@patternfly/react-catalog-view-extension';
+import { removeQueryArgument, setQueryArgument } from '../../utilities/router';
+import { PROVIDER_TYPE_FILTER_KEY } from './const';
+import { useQueryFilters } from './useQueryFilters';
+
+type ProviderTypeFiltersProps = {
+  docApps: OdhDocument[];
+  categoryApps: OdhDocument[];
+};
+
+const ProviderTypeFilters: React.FC<ProviderTypeFiltersProps> = ({ docApps, categoryApps }) => {
+  const history = useHistory();
+  const providerTypeFilters = useQueryFilters(PROVIDER_TYPE_FILTER_KEY);
+  const [showAll, setShowAll] = React.useState<boolean>(false);
+
+  const providerTypes = React.useMemo(() => {
+    const allTypes = {};
+    docApps.forEach((docApp) => {
+      if (!docApp.spec.appCategory) {
+        return;
+      }
+      allTypes[docApp.spec.appCategory] = 0;
+    });
+    categoryApps.forEach((categoryApp) => {
+      if (!categoryApp.spec.appCategory) {
+        return;
+      }
+      if (!allTypes[categoryApp.spec.appCategory]) {
+        allTypes[categoryApp.spec.appCategory] = 1;
+        return;
+      }
+      allTypes[categoryApp.spec.appCategory]++;
+    });
+    return allTypes;
+  }, [categoryApps, docApps]);
+
+  const onFilterChange = (docType: string, e: React.SyntheticEvent<HTMLElement>): void => {
+    const checked = (e.target as React.AllHTMLAttributes<HTMLInputElement>).checked;
+    const updatedQuery = [...providerTypeFilters];
+    const index = updatedQuery.indexOf(docType);
+    if (checked && index === -1) {
+      updatedQuery.push(docType);
+    }
+    if (!checked && index !== -1) {
+      updatedQuery.splice(index, 1);
+    }
+
+    if (!updatedQuery.length) {
+      removeQueryArgument(history, PROVIDER_TYPE_FILTER_KEY);
+      return;
+    }
+    setQueryArgument(history, PROVIDER_TYPE_FILTER_KEY, JSON.stringify(updatedQuery));
+  };
+
+  if (!Object.keys(providerTypes).length) {
+    return null;
+  }
+
+  return (
+    <FilterSidePanelCategory
+      key="provider-type-filter"
+      title="Provider Type"
+      onShowAllToggle={() => setShowAll(!showAll)}
+      showAll={showAll}
+    >
+      {Object.keys(providerTypes)
+        .sort((a, b) => {
+          if (a.toLowerCase().includes('red hat')) {
+            return -1;
+          }
+          return a.localeCompare(b);
+        })
+        .map((providerType) => {
+          return (
+            <FilterSidePanelCategoryItem
+              key={providerType}
+              checked={providerTypeFilters.includes(providerType)}
+              onClick={(e) => onFilterChange(providerType, e)}
+              title={providerType}
+            >
+              {`${providerType} (${providerTypes[providerType]})`}
+            </FilterSidePanelCategoryItem>
+          );
+        })}
+    </FilterSidePanelCategory>
+  );
+};
+
+export default ProviderTypeFilters;

--- a/frontend/src/pages/learningCenter/const.ts
+++ b/frontend/src/pages/learningCenter/const.ts
@@ -8,6 +8,7 @@ export const CATEGORY_FILTER_KEY = 'category';
 export const ENABLED_FILTER_KEY = 'enabled';
 export const APPLICATION_FILTER_KEY = 'provider';
 export const PROVIDER_FILTER_KEY = 'provider';
+export const PROVIDER_TYPE_FILTER_KEY = 'provider-type';
 export const DOC_SORT_KEY = 'sort';
 export const DOC_SORT_ORDER_KEY = 'order';
 

--- a/frontend/src/pages/learningCenter/useDocFilterer.ts
+++ b/frontend/src/pages/learningCenter/useDocFilterer.ts
@@ -7,6 +7,7 @@ import {
   CATEGORY_FILTER_KEY,
   DOC_TYPE_FILTER_KEY,
   ENABLED_FILTER_KEY,
+  PROVIDER_TYPE_FILTER_KEY,
   SEARCH_FILTER_KEY,
 } from './const';
 
@@ -17,6 +18,7 @@ export const useDocFilterer = (
   const enabled = queryParams.get(ENABLED_FILTER_KEY);
   const docTypes = queryParams.get(DOC_TYPE_FILTER_KEY);
   const applications = queryParams.get(APPLICATION_FILTER_KEY);
+  const providerTypes = queryParams.get(PROVIDER_TYPE_FILTER_KEY);
   const category = queryParams.get(CATEGORY_FILTER_KEY) || '';
   const searchQuery = queryParams.get(SEARCH_FILTER_KEY) || '';
 
@@ -26,8 +28,9 @@ export const useDocFilterer = (
         .filter((odhDoc) => !enabled || enabled.includes(`${odhDoc.spec.appEnabled}`))
         .filter((odhDoc) => !docTypes || docTypes.includes(`${odhDoc.metadata.type}`))
         .filter((odhDoc) => !applications || applications.includes(`${odhDoc.spec.appDisplayName}`))
+        .filter((odhDoc) => !providerTypes || providerTypes.includes(`${odhDoc.spec.appCategory}`))
         .filter((odhDoc) => matchesCategories(odhDoc, category, favorites))
         .filter((odhDoc) => matchesSearch(odhDoc, searchQuery)),
-    [enabled, docTypes, applications, category, favorites, searchQuery],
+    [enabled, docTypes, applications, providerTypes, category, favorites, searchQuery],
   );
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -60,6 +60,7 @@ export type OdhDocument = {
     appName?: string;
     appDisplayName?: string; // Only set on UI side in resources section
     appEnabled?: boolean; // Only set on UI side in resources section
+    appCategory?: string; // Only set on UI side in resources section
     provider?: string;
     description: string;
     url: string;


### PR DESCRIPTION
**Fixes**: 
Downstream should provide a filter for provider type

**Analysis / Root cause**: 
upstream does not show provider types and its not a concept upstream.

**Solution Description**: 
Add `Provider Type` to the available filters in the resources filter panel

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/122454200-1ed1f200-cf79-11eb-9fc5-7d168c455365.png)
