### PR TITLE
Add manual enablement for RHOSAK

### DIFF
--- a/data/applications/rhosak.yaml
+++ b/data/applications/rhosak.yaml
@@ -15,3 +15,11 @@ spec:
   docsLink: https://access.redhat.com/documentation/en-us/red_hat_openshift_streams_for_apache_kafka
   quickStart: connect-rhosak-notebook
   getStartedLink: https://cloud.redhat.com/beta/application-services/streams/kafkas
+  enable:
+    title: Enable OpenShift Streams for Apache Kafka
+    actionLabel: Enable
+    description: Clicking enable will add a card to the Enabled page to access the Kafka interface.
+    linkPreface: |-
+      Before enabling, be sure you can access:
+    link: https://cloud.redhat.com/beta/application-services/streams/kafkas
+    validationConfigMap: rhosak-validation-result


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-748

**Analysis / Root cause**: 
RHOSAK must use manual enablement to decide when to show in the Enabled page

**Solution Description**: 
Add the fields necessary to show the manual enable dialog

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/126776315-89ac3a7e-ec75-4633-a1ef-47dfb174c1c1.png)

