### PR TITLE
Use RHMI CR to determine RHOAM enablement

### DIFF
--- a/data/applications/rhoam.yaml
+++ b/data/applications/rhoam.yaml
@@ -7,9 +7,14 @@ spec:
   provider: Red Hat
   description: |-
     A hosted and managed API management service that accelerates time to value and reduces the operational cost of delivering API-first, microservices-based applications.
-# TODO check with RHOAM team if this is the right thing to search for.
-# If the name is locked to version, it's going to break us.
-  csvName: managed-api-service.v1.9.0
+  enableCR:
+    group: integreatly.org
+    version: v1alpha1
+    plural: rhmis
+    name: rhoam
+    namespace: redhat-rhoam-operator
+    field: status.stage
+    value: complete
   consoleLink: 'rhmi-3scale-console-link'
   img: images/red-hat.svg
   category: Red Hat managed


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-600

**Analysis / Root cause**: 
The RHOAM team has asked for a different mechanism for determining if RHOAM is enabled.
Determination should be made by checking for the existence of a CR with a field set to complete.

**Solution Description**: 
Add the CR details to the RHOAM application def file

