### PR TITLE
Update documentation link from dashboard for GA

### DIFF
--- a/.env
+++ b/.env
@@ -12,5 +12,5 @@ CONTAINER_BUILDER=docker
 IMAGE_REPOSITORY=quay.io/opendatahub/odh-dashboard:latest
 SOURCE_REPOSITORY_URL=git@github.com:red-hat-data-services/odh-dashboard.git
 SOURCE_REPOSITORY_REF=master
-DOC_LINK ='https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html-single/getting_started_with_red_hat_openshift_data_science/'
+DOC_LINK ='https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science'
 SUPPORT_LINK ='https://access.redhat.com/support/cases/#/case/new/open-case?caseCreate=true'


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1530

**Analysis / Root cause**: 
Current doc link is not correct for GA

**Solution Description**: 
Update the doc link to https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science

