### PR TITLE
Update link to cloud.rehat.com to console.redhat.com. Log errors when inspecting CR

### DIFF
--- a/backend/src/utils/componentUtils.ts
+++ b/backend/src/utils/componentUtils.ts
@@ -207,7 +207,10 @@ const getCREnabledForApp = (
       }
       return getField(existingCR, appDef.spec.enableCR.field) === appDef.spec.enableCR.value;
     })
-    .catch(() => false);
+    .catch((e) => {
+      fastify.log.error(e.response?.body?.message ?? e.message);
+      return false;
+    });
 };
 
 export const getIsAppEnabled = async (

--- a/data/applications/rhoam.yaml
+++ b/data/applications/rhoam.yaml
@@ -21,4 +21,4 @@ spec:
   support: red hat
   docsLink: https://access.redhat.com/documentation/en-us/red_hat_openshift_api_management
   quickStart: deploy-model-rhoam
-  getStartedLink: https://cloud.redhat.com/openshift/details/<CLUSTER_ID/>#addOns
+  getStartedLink: https://console.redhat.com/openshift/details/<CLUSTER_ID/>#addOns


### PR DESCRIPTION
https://issues.redhat.com/browse/RHODS-1656

cloud.redhat.com changed to console.redhat.com.
Getting started link was broken due to permissions, but we should log out errors to catch it.