### PR TITLE
Fix Seldon Deploy getting started link

### DIFF
--- a/data/applications/seldon.yaml
+++ b/data/applications/seldon.yaml
@@ -15,4 +15,4 @@ spec:
   category: Self-managed
   support: third party support
   quickStart: 'seldon-deploy-model-canary'
-  getStartedLink: 'https://deploy.seldon.io/docs/getting-started'
+  getStartedLink: 'https://deploy.seldon.io/en/latest/contents/getting-started/'


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1658

**Analysis / Root cause**: 
Getting started link for Seldon Deploy changed

**Solution Description**: 
Update the getting started link for Seldon Deploy

