### PR TITLE
UPSTREAM: Fix to more accurately communicate build statuses

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -40,6 +40,7 @@ export type K8sResourceCommon = {
 };
 
 export enum BUILD_PHASE {
+  none = 'Not started',
   new = 'New',
   running = 'Running',
   pending = 'Pending',

--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -209,7 +209,7 @@ const getBuildConfigStatus = (
       if (bcBuilds.length === 0) {
         return {
           name: notebookName,
-          status: BUILD_PHASE.pending,
+          status: BUILD_PHASE.none,
         };
       }
       const mostRecent = bcBuilds.sort(compareBuilds).pop();
@@ -229,7 +229,7 @@ const getBuildConfigStatus = (
 };
 
 export const fetchBuilds = async (fastify: KubeFastifyInstance): Promise<BuildStatus[]> => {
-  const nbBuildConfigs: K8sResourceCommon[] = await fastify.kube.customObjectsApi
+  const buildConfigs: K8sResourceCommon[] = await fastify.kube.customObjectsApi
     .listNamespacedCustomObject(
       'build.openshift.io',
       'v1',
@@ -246,25 +246,6 @@ export const fetchBuilds = async (fastify: KubeFastifyInstance): Promise<BuildSt
     .catch(() => {
       return [];
     });
-  const baseBuildConfigs: K8sResourceCommon[] = await fastify.kube.customObjectsApi
-    .listNamespacedCustomObject(
-      'build.openshift.io',
-      'v1',
-      fastify.kube.namespace,
-      'buildconfigs',
-      undefined,
-      undefined,
-      undefined,
-      'opendatahub.io/build_type=base_image',
-    )
-    .then((res) => {
-      return (res?.body as { items: K8sResourceCommon[] })?.items;
-    })
-    .catch(() => {
-      return [];
-    });
-
-  const buildConfigs = [...nbBuildConfigs, ...baseBuildConfigs];
 
   const getters = buildConfigs.map(async (buildConfig) => {
     return getBuildConfigStatus(fastify, buildConfig);

--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -42,8 +42,17 @@ html, body, #root {
         padding-bottom: 0;
       }
     }
+    &__message {
+      .pf-c-notification-drawer__list & {
+        margin-left: var(--pf-global--spacer--lg);
+      }
+    }
+    &__list {
+      list-style: disc;
+      margin-left: 20px;
+      margin-bottom: var(--pf-global--spacer--sm);
+    }
   }
-
   &__favorite {
     cursor: pointer;
     position: relative;

--- a/frontend/src/app/AppNotificationDrawer.tsx
+++ b/frontend/src/app/AppNotificationDrawer.tsx
@@ -26,7 +26,7 @@ interface AppNotificationDrawerProps {
 const AppNotificationDrawer: React.FC<AppNotificationDrawerProps> = ({ onClose }) => {
   const notifications: AppNotification[] = useSelector<State, AppNotification[]>(
     (state) => state.appState.notifications,
-  );
+  ).sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
   const dispatch = useDispatch();
   const newNotifications = React.useMemo(() => {
     return notifications.filter((notification) => !notification.read).length;
@@ -67,7 +67,6 @@ const AppNotificationDrawer: React.FC<AppNotificationDrawerProps> = ({ onClose }
                 <NotificationDrawerListItemHeader
                   variant={notification.status}
                   title={notification.title}
-                  srTitle={notification.title}
                 >
                   <div>
                     <Button

--- a/frontend/src/redux/types.ts
+++ b/frontend/src/redux/types.ts
@@ -14,9 +14,10 @@ export enum Actions {
   FORCE_COMPONENTS_UPDATE = 'FORCE_COMPONENTS_UPDATE',
 }
 
+export type AppNotificationStatus = 'success' | 'danger' | 'warning' | 'info' | 'default';
 export interface AppNotification {
   id?: number;
-  status: 'success' | 'danger' | 'warning' | 'info' | 'default';
+  status: AppNotificationStatus;
   title: string;
   message?: React.ReactNode;
   hidden?: boolean;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -88,6 +88,7 @@ export type OdhGettingStarted = {
 };
 
 export enum BUILD_PHASE {
+  none = 'Not started',
   new = 'New',
   running = 'Running',
   pending = 'Pending',

--- a/install/odh/base/deployment.yaml
+++ b/install/odh/base/deployment.yaml
@@ -15,17 +15,17 @@ spec:
       serviceAccount: odh-dashboard
       containers:
       - name: odh-dashboard
-        image: quay.io/opendatahub/odh-dashboard:latest
+        image: quay.io/modh/odh-dashboard:v1.0.11
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
         resources:
           requests:
-            cpu: 250m
-            memory: 300Mi
+            cpu: 300m
+            memory: 500Mi
           limits:
             cpu: 500m
-            memory: 1000Mi
+            memory: 1Gi
         livenessProbe:
           httpGet:
             path: /api/status
@@ -46,3 +46,5 @@ spec:
           periodSeconds: 30
           successThreshold: 1
           failureThreshold: 3
+      imagePullSecrets:
+      - name: addon-managed-odh-pullsecret


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1649
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
