### PR TITLE
Add default quick start for Anaconda CE

### DIFF
--- a/backend/src/routes/api/segment-key/segmentKeyUtils.ts
+++ b/backend/src/routes/api/segment-key/segmentKeyUtils.ts
@@ -10,7 +10,9 @@ export const getSegmentKey = async (fastify: KubeFastifyInstance): Promise<ODHSe
       segmentKey: decodedSegmentKey,
     };
   } catch (e) {
-    fastify.log.error('load segment key error: ' + e);
+    if (e.response?.statusCode !== 404) {
+      fastify.log.error('load segment key error: ' + e);
+    }
     return {
       segmentKey: '',
     };

--- a/backend/src/utils/componentUtils.ts
+++ b/backend/src/utils/componentUtils.ts
@@ -208,7 +208,13 @@ const getCREnabledForApp = (
       return getField(existingCR, appDef.spec.enableCR.field) === appDef.spec.enableCR.value;
     })
     .catch((e) => {
-      fastify.log.error(e.response?.body?.message ?? e.message);
+      if (e.response?.statusCode !== 404) {
+        fastify.log.error(
+          `Unable to read ${group}/${version}:${plural} ${name} : ${
+            e.response?.body?.message ?? e.message
+          }`,
+        );
+      }
       return false;
     });
 };

--- a/data/applications/anaconda-ce.yaml
+++ b/data/applications/anaconda-ce.yaml
@@ -12,7 +12,7 @@ spec:
   category: Partner managed
   support: third party support
   docsLink: https://docs.anaconda.com/
-  quickStart: ''
+  quickStart: 'create-jupyter-notebook-anaconda'
   getStartedLink: https://anaconda.cloud/register?utm_source=redhat-rhods-summit
   enable:
     title: Connect Anaconda to JupyterHub


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1866

**Analysis / Root cause**: 
The default quick start for Anaconda CE was not set in it's application definition yaml

**Solution Description**: 
Add the quick start to the app def. Also, add some expected failure checks to avoid flooding the logs with unnecessary false errors.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1866
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
