### PR TITLE
Fix for punctuation on Seldon drift quick start description

### DIFF
--- a/data/quickstarts/seldon-deploy-drift-quickstart.yaml
+++ b/data/quickstarts/seldon-deploy-drift-quickstart.yaml
@@ -8,7 +8,7 @@ spec:
   appName: seldon-deploy
   durationMinutes: 10
   icon: 'images/seldon.svg'
-  description: Monitor drift for a deployed image classifier model
+  description: Monitor drift for a deployed image classifier model.
   introduction: |-
     ### This quick start shows you how to launch a TensorFlow image classifier model and detect when requests to the model are drifting.
     Seldon Deploy is a specialist set of tools designed to simplify and accelerate the process of deploying and managing your machine learning models.

--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -122,9 +122,6 @@ html, body, #root {
     }
   }
 
-  .pf-c-app-launcher {
-    font-size: var(--pf-global--FontSize--sm);
-  }
   .pf-c-app-launcher__group-title {
     font-size: 13px;
   }
@@ -132,6 +129,18 @@ html, body, #root {
   .pf-c-app-launcher__menu-item-external-icon {
     opacity: 1;
     color: var(--pf-global--icon--Color--light);
+  }
+}
+// specificity targeting form elements to override --pf-global--FontSize--md
+.pf-c-page, .pf-c-modal-box {
+  .pf-c-app-launcher,
+  .pf-c-button,
+  .pf-c-dropdown,
+  .pf-c-dropdown__menu-item,
+  .pf-c-dropdown__toggle,
+  .pf-c-form-control {
+    font-size: 14px;
+    height: auto;
   }
 }
 


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1893

**Analysis / Root cause**: 
Missing period at the end of the sentence describing the Seldon drift quick start
Also, dropdown item, menu items and button font sizes are not consistent w/ console.

**Solution Description**: 
Added the period at the end of the description.
Added the override for dropdown item, menu items and button font sizes to be consistent with console.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1893
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
