### PR TITLE
Hide 'GPU Computing' tutorial behind a feature flag

### DIFF
--- a/data/docs/python-gpu-numba-tutorial.yaml
+++ b/data/docs/python-gpu-numba-tutorial.yaml
@@ -10,3 +10,4 @@ spec:
     Learn how to create GPU accelerated functions using Numba.
   url: https://github.com/ContinuumIO/gtc2018-numba
   durationMinutes: 90
+  featureFlag: gpu-computing

--- a/data/features.json
+++ b/data/features.json
@@ -1,3 +1,4 @@
 {
-  "example-feature-app-name": true
+  "example-feature-app-name": true,
+  "gpu-computing": false
 }


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1918

**Analysis / Root cause**: 
GPU selection is not available so  the tutorials about GPU computing (i.e., GPU Computing in Python with Numba) should be hidden in the "Resources" tab of RHODS 

**Solution Description**: 
Mark the `GPU Computing in Python with Numba` tutorial as requiring a feature flag of `gpu-computing` which is set to false.

- [x] - [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1918
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
