### PR TITLE
Add config option to disable access to cluster manager

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -6,6 +6,7 @@ export type DashboardConfig = {
   enablement: boolean;
   disableInfo: boolean;
   disableSupport: boolean;
+  disableClusterManager: boolean;
 };
 
 // Add a minimal QuickStart type here as there is no way to get types without pulling in frontend (React) modules

--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -48,6 +48,7 @@ const DEFAULT_DASHBOARD_CONFIG: V1ConfigMap = {
     enablement: 'true',
     disableInfo: 'false',
     disableSupport: 'false',
+    disableClusterManager: 'false',
   },
 };
 
@@ -295,6 +296,7 @@ export const getDashboardConfig = (): DashboardConfig => {
     enablement: (config.data?.enablement ?? '').toLowerCase() !== 'false',
     disableInfo: (config.data?.disableInfo ?? '').toLowerCase() === 'true',
     disableSupport: (config.data?.disableSupport ?? '').toLowerCase() === 'true',
+    disableClusterManager: (config.data?.disableClusterManager ?? '').toLowerCase() === 'true',
   };
 };
 

--- a/frontend/src/app/AppLauncher.tsx
+++ b/frontend/src/app/AppLauncher.tsx
@@ -9,6 +9,7 @@ import {
 import openshiftLogo from '../images/openshift.svg';
 import { RootState } from '../redux/types';
 import { useWatchConsoleLinks } from '../utilities/useWatchConsoleLinks';
+import { DashboardConfig } from '../types';
 
 type ApplicationAction = {
   label: string;
@@ -66,7 +67,11 @@ const sectionSortValue = (section: Section): number => {
   }
 };
 
-const AppLauncher: React.FC = () => {
+type AppLauncherProps = {
+  dashboardConfig: DashboardConfig;
+};
+
+const AppLauncher: React.FC<AppLauncherProps> = ({ dashboardConfig }) => {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const [clusterID, clusterBranding] = useSelector((state: RootState) => [
     state.appState.clusterID,
@@ -84,7 +89,9 @@ const AppLauncher: React.FC = () => {
 
     const getRHApplications = (): Section[] => {
       const osConsoleAction = getOpenShiftConsoleAction();
-      const ocmAction = getOCMAction(clusterID, clusterBranding);
+      const ocmAction = dashboardConfig.disableClusterManager
+        ? null
+        : getOCMAction(clusterID, clusterBranding);
 
       if (!osConsoleAction && !ocmAction) {
         return [];

--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -101,7 +101,7 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
   return (
     <PageHeaderTools>
       <PageHeaderToolsGroup className="hidden-xs">
-        <AppLauncher />
+        <AppLauncher dashboardConfig={dashboardConfig} />
         <PageHeaderToolsItem>
           <NotificationBadge isRead count={newNotifications} onClick={onNotificationsClick} />
         </PageHeaderToolsItem>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,6 +6,7 @@ export type DashboardConfig = {
   enablement: boolean;
   disableInfo: boolean;
   disableSupport: boolean;
+  disableClusterManager: boolean;
 };
 
 export type OdhApplication = {

--- a/frontend/src/utilities/useWatchDashboardConfig.tsx
+++ b/frontend/src/utilities/useWatchDashboardConfig.tsx
@@ -8,6 +8,7 @@ const DEFAULT_CONFIG: DashboardConfig = {
   enablement: true,
   disableInfo: false,
   disableSupport: false,
+  disableClusterManager: false,
 };
 
 export const useWatchDashboardConfig = (): {


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1945

The sandbox users will not have access to cluster management and therefore the link to Cluster manager console is useless.  


**Analysis / Root cause**: 
The dashboard only checks for the availability of the cluster manager it does not know if the user has access.

**Solution Description**: 
Add a config setting to disable access to the cluster manager.

Example config map with disablement:

```
kind: ConfigMap
apiVersion: v1
metadata:
  name: odh-dashboard-config
  namespace: redhat-ods-applications
  uid: 3b8092d5-94b0-45d4-b010-1bd88e5968ff
  resourceVersion: '100273'
  creationTimestamp: '2021-09-24T12:37:29Z'
  managedFields:
    - manager: Mozilla
      operation: Update
      apiVersion: v1
      time: '2021-09-24T12:37:29Z'
      fieldsType: FieldsV1
      fieldsV1:
        'f:data':
          .: {}
          'f:disableClusterManager': {}
          'f:disableInfo': {}
          'f:disableSupport': {}
          'f:enablement': {}
data:
  disableClusterManager: 'true'
  disableInfo: 'false'
  disableSupport: 'false'
  enablement: 'true'
```


- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1945
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
