### PR TITLE
Update AI Kit app def to not be feature flagged out

### DIFF
--- a/data/applications/aikit.yaml
+++ b/data/applications/aikit.yaml
@@ -7,12 +7,11 @@ spec:
   provider: Intel®
   description: |-
     A comprehensive set of interoperable AI software tools, built using oneAPI, to provide drop-in acceleration for end to end data science and machine learning pipelines on Intel architectures with familiar Python libraries and frameworks.
-  kfdefApplications: ['jupyterhub', 'notebook-images']
   route: jupyterhub
   img: images/oneapi.png
-  category: Intel® managed
-  support: Intel®
+  category: Self managed
+  support: third party support
+  csvName: aikit-operator
   docsLink: https://software.intel.com/content/www/us/en/develop/tools/oneapi/ai-analytics-toolkit.html
   quickStart: create-aikit-notebook
   getStartedLink: https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-ai-linux/top.html
-  featureFlag: aikit

--- a/frontend/src/app/AppLauncher.tsx
+++ b/frontend/src/app/AppLauncher.tsx
@@ -127,7 +127,7 @@ const AppLauncher: React.FC<AppLauncherProps> = ({ dashboardConfig }) => {
     sections.sort((a, b) => sectionSortValue(a) - sectionSortValue(b));
 
     return sections;
-  }, [clusterBranding, clusterID, consoleLinks]);
+  }, [clusterBranding, clusterID, consoleLinks, dashboardConfig.disableClusterManager]);
 
   const onToggle = () => {
     setIsOpen((prev) => !prev);


### PR DESCRIPTION
**Fixes**: 
Jira:
  https://issues.redhat.com/browse/RHODS-1818
  https://issues.redhat.com/browse/RHODS-1819

**Analysis / Root cause**: 
AiKit was not ready and was hidden via a feature flag.
We did not know the CSV to look for in order to enable AiKit

**Solution Description**: 
Remove the feature flag and update the enablement mechanism

**Screen shots / Gifs for design review**: 

![image](https://user-images.githubusercontent.com/11633780/134700884-ce9458ed-0d94-4267-a53b-ec206b045981.png)


- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1818, https://issues.redhat.com/browse/RHODS-1819
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
