### PR TITLE
RHODS-2213: Fix for extra scikit category.

### DIFF
--- a/data/quickstarts/oneapi-aikit-notebook.yaml
+++ b/data/quickstarts/oneapi-aikit-notebook.yaml
@@ -3,7 +3,7 @@ kind: ConsoleQuickStart
 metadata:
   name: create-aikit-notebook
   annotations:
-    opendatahub.io/categories: 'AI/Machine learning,Getting started,Jupyter notebook,Python,oneAPI,Scikit-Learn,Pandas,TensorFlow,PyTorch,Modin,LPOT'
+    opendatahub.io/categories: 'AI/Machine learning,Getting started,Jupyter notebook,Python,oneAPI,SciKit-Learn,Pandas,TensorFlow,PyTorch,Modin,LPOT'
 
 spec:
   displayName: Using the Intel® oneAPI AI Analytics Toolkit (AI Kit) notebook 


### PR DESCRIPTION
Removes the extra scikit category.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2213
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
