### PR TITLE
Track tile-usage on Explore tab

### DIFF
--- a/frontend/src/pages/exploreApplication/ExploreApplications.tsx
+++ b/frontend/src/pages/exploreApplication/ExploreApplications.tsx
@@ -17,6 +17,7 @@ import { OdhApplication } from '../../types';
 import GetStartedPanel from './GetStartedPanel';
 import { useQueryParams } from '../../utilities/useQueryParams';
 import { removeQueryArgument, setQueryArgument } from '../../utilities/router';
+import { fireTrackingEvent } from '../../utilities/segmentIOUtils';
 
 import './ExploreApplications.scss';
 
@@ -68,7 +69,12 @@ const ExploreApplicationsInner: React.FC<ExploreApplicationsInnerProps> = React.
                           key={c.metadata.name}
                           odhApp={c}
                           isSelected={selectedComponent?.metadata.name === c.metadata.name}
-                          onSelect={() => updateSelection(c.metadata.name)}
+                          onSelect={() => {
+                            updateSelection(c.metadata.name);
+                            fireTrackingEvent('Explore card clicked', {
+                              name: c.metadata.name,
+                            });
+                          }}
                           disableInfo={dashboardConfig.disableInfo}
                           enableOpen={c.metadata.name === enableApp?.metadata.name}
                           onEnableClose={() => setEnableApp(undefined)}

--- a/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
+++ b/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
@@ -22,6 +22,7 @@ import { useWatchDashboardConfig } from '../../utilities/useWatchDashboardConfig
 import { useGettingStarted } from '../../utilities/useGettingStarted';
 import MarkdownView from '../../components/MarkdownView';
 import { markdownConverter } from '../../utilities/markdown';
+import { fireTrackingEvent } from '../../utilities/segmentIOUtils';
 
 import './GetStartedPanel.scss';
 
@@ -125,6 +126,11 @@ const GetStartedPanel: React.FC<GetStartedPanelProps> = ({ selectedApp, onClose,
               href={selectedApp.spec.getStartedLink}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() =>
+                fireTrackingEvent('Explore card get started clicked', {
+                  name: selectedApp.metadata.name,
+                })
+              }
             >
               <span className="odh-get-started__get-started-text">Get started</span>
               <ExternalLinkAltIcon />


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2327
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
