### PR TITLE
Remove Starburst Beta Text from the getting started

### DIFF
--- a/data/applications/starburst.yaml
+++ b/data/applications/starburst.yaml
@@ -15,9 +15,6 @@ spec:
   support: third party support
   quickStart: ''
   getStartedLink: https://www.starburst.io/platform/starburst-galaxy/
-  beta: true
-  betaText: |-
-    This application is available for early access prior to official
-    release. It won’t appear in the *Enabled* view, but you can access it by
-    [signing up for beta access.](https://www.starburst.io/platform/starburst-galaxy/).
+  beta: false
+  betaText: ''
 

--- a/data/getting-started/starburst.md
+++ b/data/getting-started/starburst.md
@@ -9,5 +9,5 @@
 * Support: 24x7 support from the Trino experts; in a fully-managed environment.
 * Get started in a matter of minutes: Starburst Galaxy improves the time to value in your data and analytics.
 
-You can access Starburst Galaxy by signing up here [here](https://www.starburst.io/platform/starburst-galaxy/). Starburst is currently offering a free trial of $500 in usage, so you can try before you buy.
+You can access Starburst Galaxy by signing up [here](https://www.starburst.io/platform/starburst-galaxy/). Starburst is currently offering a free trial of $500 in usage, so you can try before you buy.
 


### PR DESCRIPTION
set beta to false since starburst galaxy is now a GA offering

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s): https://issues.redhat.com/browse/RHODS-2984
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
