### PR TITLE
FeatureFlagging Watson Studio since it is not compatible with OpenShift 4.9+ for now

### DIFF
--- a/data/applications/watson-studio.yaml
+++ b/data/applications/watson-studio.yaml
@@ -17,3 +17,4 @@ spec:
   support: third party support
   quickStart: build-deploy-watson-model
   getStartedLink: https://developer.ibm.com/series/cloud-pak-for-data-learning-path
+  featureFlag: watson

--- a/data/features.json
+++ b/data/features.json
@@ -1,4 +1,5 @@
 {
   "example-feature-app-name": true,
-  "gpu-computing": false
+  "gpu-computing": false,
+  "watson": false
 }

--- a/data/quickstarts/deploy-watson-model-quickstart.yaml
+++ b/data/quickstarts/deploy-watson-model-quickstart.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     opendatahub.io/categories: 'AI/Machine learning,Deployment,Jupyter notebook,Model serving,Python'
 spec:
+  featureFlag: watson
   displayName: Deploying a model with Watson Studio
   appName: watson-studio
   durationMinutes: 15


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2883
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [x] The developer has manually tested the changes and verified that the changes work.
