### PR TITLE
revert 2883

### DIFF
--- a/data/applications/watson-studio.yaml
+++ b/data/applications/watson-studio.yaml
@@ -17,4 +17,3 @@ spec:
   support: third party support
   quickStart: build-deploy-watson-model
   getStartedLink: https://developer.ibm.com/series/cloud-pak-for-data-learning-path
-  featureFlag: watson

--- a/data/features.json
+++ b/data/features.json
@@ -1,5 +1,4 @@
 {
   "example-feature-app-name": true,
-  "gpu-computing": false,
-  "watson": false
+  "gpu-computing": false
 }

--- a/data/quickstarts/deploy-watson-model-quickstart.yaml
+++ b/data/quickstarts/deploy-watson-model-quickstart.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     opendatahub.io/categories: 'AI/Machine learning,Deployment,Jupyter notebook,Model serving,Python'
 spec:
-  featureFlag: watson
   displayName: Deploying a model with Watson Studio
   appName: watson-studio
   durationMinutes: 15


### PR DESCRIPTION
- Revert "FeatureFlagging Watson Studio since it is not compatible with OpenShift 4.9+ for now"
- Revert "Hiding IBM Watson from Resources section of ODH"
