### PR TITLE
[UPSTREAM] Fix for CPU and Memory issues fetching resources

### DIFF
--- a/backend/src/routes/api/status/index.ts
+++ b/backend/src/routes/api/status/index.ts
@@ -38,7 +38,7 @@ const status = async (
   } catch (e) {
     console.log('Failed to get groups: ' + e.toString());
   }
-  fastify.kube.coreV1Api.getAPIResources();
+
   if (!kubeContext && !kubeContext.trim()) {
     const error = createError(500, 'failed to get kube status');
     error.explicitInternalServerError = true;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -13,7 +13,7 @@ export type ClusterSettings = {
   pvcSize: number;
   cullerTimeout: number;
   userTrackingEnabled: boolean;
-}
+};
 
 // Add a minimal QuickStart type here as there is no way to get types without pulling in frontend (React) modules
 export declare type QuickStart = {
@@ -76,6 +76,16 @@ export type RouteKind = {
     host?: string;
     tls?: {
       termination: string;
+    };
+  };
+} & K8sResourceCommon;
+
+// Minimal type for Subscriptions
+export type SubscriptionKind = {
+  status: {
+    installedCSV: string;
+    installPlanRef: {
+      namespace: string;
     };
   };
 } & K8sResourceCommon;

--- a/backend/src/utils/componentUtils.ts
+++ b/backend/src/utils/componentUtils.ts
@@ -5,13 +5,9 @@ import {
   KubeFastifyInstance,
   RouteKind,
   KfDefApplication,
+  CSVKind,
 } from '../types';
-import {
-  getConsoleLinks,
-  getInstalledKfdefs,
-  getInstalledOperators,
-  getServices,
-} from './resourceUtils';
+import { getConsoleLinks, getInstalledKfdefs, getSubscriptions } from './resourceUtils';
 
 type RoutesResponse = {
   body: {
@@ -58,7 +54,7 @@ export const getLink = async (
       .then((res) => res.body as RouteKind);
     return getURLForRoute(route, routeSuffix);
   } catch (e) {
-    fastify.log.error(`failed to get route ${routeName} in namespace ${namespace}`);
+    fastify.log.info(`failed to get route ${routeName} in namespace ${namespace}`);
     return null;
   }
 };
@@ -80,8 +76,12 @@ export const getServiceLink = async (
   if (!serviceName) {
     return null;
   }
-  const services = getServices();
-  const service = services.find((service) => service.metadata.name === serviceName);
+  const res = await fastify.kube.coreV1Api.listServiceForAllNamespaces(
+    undefined,
+    undefined,
+    `metadata.name=${serviceName}`,
+  );
+  const service = res?.body.items?.[0];
   if (!service) {
     return null;
   }
@@ -94,7 +94,7 @@ export const getServiceLink = async (
       .then((res: RoutesResponse) => res?.body?.items);
     return getURLForRoute(routes?.[0], routeSuffix);
   } catch (e) {
-    fastify.log.error(`failed to get route in namespace ${namespace}`);
+    fastify.log.info(`failed to get route in namespace ${namespace}`);
     return null;
   }
 };
@@ -109,7 +109,13 @@ export const getRouteForApplication = async (
     return route;
   }
 
-  const operatorCSV = getCSVForApp(app);
+  // Check for specified route
+  route = await getLink(fastify, app.spec.route);
+  if (route) {
+    return route;
+  }
+
+  const operatorCSV = await getCSVForApp(fastify, app);
   // Check for CSV route
   route = await getLink(
     fastify,
@@ -121,14 +127,8 @@ export const getRouteForApplication = async (
     return route;
   }
 
-  // Check for specified route
-  route = await getLink(fastify, app.spec.route);
-  if (route) {
-    return route;
-  }
-
   // Check for console link
-  route = await getConsoleLinkRoute(app);
+  route = getConsoleLinkRoute(app);
   if (route) {
     return route;
   }
@@ -159,11 +159,37 @@ export const getApplicationEnabledConfigMap = async (
   return enabledCM.data?.validation_result === 'true';
 };
 
-const getCSVForApp = (app: OdhApplication): K8sResourceCommon | undefined => {
-  const operatorCSVs = getInstalledOperators();
-  return operatorCSVs.find(
-    (operator) => app.spec.csvName && operator.metadata?.name?.startsWith(app.spec.csvName),
+const getCSVForApp = (
+  fastify: KubeFastifyInstance,
+  app: OdhApplication,
+): Promise<K8sResourceCommon | undefined> => {
+  if (!app.spec.csvName) {
+    return Promise.resolve(undefined);
+  }
+
+  const subscriptions = getSubscriptions();
+  const appSubscription = subscriptions.find((sub) =>
+    sub.status.installedCSV.startsWith(app.spec.csvName),
   );
+  if (!appSubscription) {
+    return Promise.resolve(undefined);
+  }
+
+  return fastify.kube.customObjectsApi
+    .getNamespacedCustomObject(
+      'operators.coreos.com',
+      'v1alpha1',
+      appSubscription.status.installPlanRef.namespace,
+      'clusterserviceversions',
+      appSubscription.status.installedCSV,
+    )
+    .then((response) => {
+      const csv = response.body as CSVKind;
+      if (csv.status?.phase === 'Succeeded') {
+        return csv;
+      }
+      return undefined;
+    });
 };
 
 const getKfDefForApp = (appDef: OdhApplication): KfDefApplication | undefined => {
@@ -223,10 +249,6 @@ export const getIsAppEnabled = async (
   fastify: KubeFastifyInstance,
   appDef: OdhApplication,
 ): Promise<boolean> => {
-  if (getCSVForApp(appDef)) {
-    return true;
-  }
-
   if (getKfDefForApp(appDef)) {
     return true;
   }
@@ -237,6 +259,10 @@ export const getIsAppEnabled = async (
   }
   const crEnabled = await getCREnabledForApp(fastify, appDef);
   if (crEnabled) {
+    return true;
+  }
+
+  if (await getCSVForApp(fastify, appDef)) {
     return true;
   }
 

--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -8,7 +8,6 @@ import {
   BuildKind,
   BuildStatus,
   ConsoleLinkKind,
-  CSVKind,
   DashboardConfig,
   K8sResourceCommon,
   KfDefApplication,
@@ -16,9 +15,11 @@ import {
   KubeFastifyInstance,
   OdhApplication,
   OdhDocument,
+  SubscriptionKind,
 } from '../types';
 import {
   DEFAULT_ACTIVE_TIMEOUT,
+  DEFAULT_INACTIVE_TIMEOUT,
   ResourceWatcher,
   ResourceWatcherTimeUpdate,
 } from './resourceWatcher';
@@ -33,8 +34,7 @@ const consoleLinksPlural = 'consolelinks';
 const enabledAppsConfigMapName = process.env.ENABLED_APPS_CM;
 
 let dashboardConfigWatcher: ResourceWatcher<V1ConfigMap>;
-let operatorWatcher: ResourceWatcher<CSVKind>;
-let serviceWatcher: ResourceWatcher<K8sResourceCommon>;
+let subscriptionWatcher: ResourceWatcher<SubscriptionKind>;
 let appWatcher: ResourceWatcher<OdhApplication>;
 let docWatcher: ResourceWatcher<OdhDocument>;
 let kfDefWatcher: ResourceWatcher<KfDefApplication>;
@@ -61,44 +61,48 @@ const fetchDashboardConfigMap = (fastify: KubeFastifyInstance): Promise<V1Config
     .catch(() => [DEFAULT_DASHBOARD_CONFIG]);
 };
 
-const fetchInstalledOperators = (fastify: KubeFastifyInstance): Promise<CSVKind[]> => {
-  return fastify.kube.customObjectsApi
-    .listNamespacedCustomObject('operators.coreos.com', 'v1alpha1', '', 'clusterserviceversions')
-    .then((res) => {
-      const csvs = (res?.body as { items: CSVKind[] })?.items;
-      if (csvs?.length) {
-        return csvs.reduce((acc, csv) => {
-          if (csv.status?.phase === 'Succeeded' && csv.status?.reason === 'InstallSucceeded') {
-            acc.push(csv);
-          }
-          return acc;
-        }, []);
+const fetchSubscriptions = (fastify: KubeFastifyInstance): Promise<SubscriptionKind[]> => {
+  const fetchAll = async (): Promise<SubscriptionKind[]> => {
+    const subscriptions: SubscriptionKind[] = [];
+    let _continue: string = undefined;
+    let remainingItemCount = 1;
+    try {
+      while (remainingItemCount) {
+        const res = (await fastify.kube.customObjectsApi.listNamespacedCustomObject(
+          'operators.coreos.com',
+          'v1alpha1',
+          '',
+          'subscriptions',
+          undefined,
+          _continue,
+          undefined,
+          undefined,
+          250,
+        )) as {
+          body: {
+            items: SubscriptionKind[];
+            metadata: { _continue: string; remainingItemCount: number };
+          };
+        };
+        const subs = res?.body.items;
+        remainingItemCount = res.body?.metadata?.remainingItemCount;
+        _continue = res.body?.metadata?._continue;
+        if (subs?.length) {
+          subscriptions.push(...subs);
+        }
       }
-      return [];
-    })
-    .catch((e) => {
-      console.error(e, 'failed to get ClusterServiceVersions');
-      return [];
-    });
-};
-
-const fetchServices = (fastify: KubeFastifyInstance) => {
-  return fastify.kube.coreV1Api
-    .listServiceForAllNamespaces()
-    .then((res) => {
-      return res?.body?.items;
-    })
-    .catch((e) => {
-      console.error(e, 'failed to get Services');
-      return [];
-    });
+    } catch (e) {
+      console.log(`ERROR: `, e.body.message);
+    }
+    return subscriptions;
+  };
+  return fetchAll();
 };
 
 const fetchInstalledKfdefs = async (fastify: KubeFastifyInstance): Promise<KfDefApplication[]> => {
   const customObjectsApi = fastify.kube.customObjectsApi;
   const namespace = fastify.kube.namespace;
 
-  let kfdef: KfDefResource;
   try {
     const res = await customObjectsApi.listNamespacedCustomObject(
       'kfdef.apps.kubeflow.org',
@@ -106,7 +110,13 @@ const fetchInstalledKfdefs = async (fastify: KubeFastifyInstance): Promise<KfDef
       namespace,
       'kfdefs',
     );
-    kfdef = (res?.body as { items: KfDefResource[] })?.items?.[0];
+    const kfdefs = (res?.body as { items: KfDefResource[] })?.items;
+    return kfdefs.reduce((acc, kfdef) => {
+      if (kfdef?.spec?.applications?.length) {
+        acc.push(...kfdef.spec.applications);
+      }
+      return acc;
+    }, [] as KfDefApplication[]);
   } catch (e) {
     fastify.log.error(e, 'failed to get kfdefs');
     const error = createError(500, 'failed to get kfdefs');
@@ -116,8 +126,6 @@ const fetchInstalledKfdefs = async (fastify: KubeFastifyInstance): Promise<KfDef
       'Unable to load Kubeflow resources. Please ensure the Open Data Hub operator has been installed.';
     throw error;
   }
-
-  return kfdef?.spec?.applications || [];
 };
 
 const fetchApplicationDefs = async (fastify: KubeFastifyInstance): Promise<OdhApplication[]> => {
@@ -307,10 +315,13 @@ const getRefreshTimeForBuilds = (buildStatuses: BuildStatus[]): ResourceWatcherT
     runningStatuses.includes(buildStatus.status.toLowerCase()),
   );
   if (building.length) {
-    return { activeWatchInterval: 30 * 1000 };
+    return { activeWatchInterval: 30 * 1000, inactiveWatchInterval: DEFAULT_INACTIVE_TIMEOUT };
   }
 
-  return { activeWatchInterval: DEFAULT_ACTIVE_TIMEOUT };
+  return {
+    activeWatchInterval: DEFAULT_ACTIVE_TIMEOUT,
+    inactiveWatchInterval: DEFAULT_INACTIVE_TIMEOUT,
+  };
 };
 
 const fetchConsoleLinks = async (fastify: KubeFastifyInstance) => {
@@ -327,8 +338,7 @@ const fetchConsoleLinks = async (fastify: KubeFastifyInstance) => {
 
 export const initializeWatchedResources = (fastify: KubeFastifyInstance): void => {
   dashboardConfigWatcher = new ResourceWatcher<V1ConfigMap>(fastify, fetchDashboardConfigMap);
-  operatorWatcher = new ResourceWatcher<CSVKind>(fastify, fetchInstalledOperators);
-  serviceWatcher = new ResourceWatcher<K8sResourceCommon>(fastify, fetchServices);
+  subscriptionWatcher = new ResourceWatcher<SubscriptionKind>(fastify, fetchSubscriptions);
   kfDefWatcher = new ResourceWatcher<KfDefApplication>(fastify, fetchInstalledKfdefs);
   appWatcher = new ResourceWatcher<OdhApplication>(fastify, fetchApplicationDefs);
   docWatcher = new ResourceWatcher<OdhDocument>(fastify, fetchDocs);
@@ -346,12 +356,8 @@ export const getDashboardConfig = (): DashboardConfig => {
   };
 };
 
-export const getInstalledOperators = (): K8sResourceCommon[] => {
-  return operatorWatcher.getResources();
-};
-
-export const getServices = (): K8sResourceCommon[] => {
-  return serviceWatcher.getResources();
+export const getSubscriptions = (): SubscriptionKind[] => {
+  return subscriptionWatcher.getResources();
 };
 
 export const getInstalledKfdefs = (): KfDefApplication[] => {

--- a/backend/src/utils/resourceWatcher.ts
+++ b/backend/src/utils/resourceWatcher.ts
@@ -52,17 +52,29 @@ export class ResourceWatcher<T> {
       );
       if (activeWatchInterval !== this.activeWatchInterval) {
         this.activeWatchInterval = activeWatchInterval;
-        updated = true;
+        if (this.activelyWatching) {
+          updated = true;
+        }
       }
       if (inactiveWatchInterval !== this.inactiveWatchInterval) {
         this.inactiveWatchInterval = inactiveWatchInterval;
-        updated = true;
+        if (!this.activelyWatching) {
+          updated = true;
+        }
       }
     }
     return updated;
   }
 
   startWatching(active: boolean): void {
+    // if still starting up, wait for initial results
+    if (this.watchTimer === null) {
+      if (active) {
+        this.activelyWatching = true;
+      }
+      return;
+    }
+
     if (this.watchTimer !== undefined) {
       if (active === this.activelyWatching) {
         return;
@@ -78,6 +90,9 @@ export class ResourceWatcher<T> {
         // Swallow any exceptions
       })
       .finally(() => {
+        if (this.watchTimer) {
+          return;
+        }
         this.watchTimer = setInterval(
           () => {
             if (this.watchTimer) {


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): [RHODS-3191](https://issues.redhat.com/browse/RHODS-3191)
- [x] The Jira story is acked
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [x] The developer has manually tested the changes and verified that the changes work.

**Testing:**  Operator performance test should be completed on a cluster with multiple installed operators and created resources for many users.  For this, https://github.com/codeready-toolchain/toolchain-e2e/tree/master/setup can be used to test kubeapi memory consumption.  Memory can be observed from test results and the on cluster metrics.  For regression testing, we must make sure the add-ons for AIKit, OpenVino, Pachyderm, Seldon, and Watson Studio are all still working. 

**(Updated) Live Build:** `quay.io/modh/rhods-operator-live-catalog:1.11.0-rhods-3191`