### PR TITLE
[UPSTREAM] Fixed progress showing incorrectly for Quick Starts. (#206)

### DIFF
--- a/frontend/src/components/DocCardBadges.tsx
+++ b/frontend/src/components/DocCardBadges.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Label, Tooltip } from '@patternfly/react-core';
-import { SyncAltIcon, CheckCircleIcon } from '@patternfly/react-icons';
+import { SyncAltIcon, CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { QuickStartContext, QuickStartContextValues } from '@patternfly/quickstarts';
 import { OdhDocument, OdhDocumentType } from '../types';
-import { isQuickStartComplete, isQuickStartInProgress } from '../utilities/quickStartUtils';
+import { getQuickStartCompletionStatus, CompletionStatusEnum } from '../utilities/quickStartUtils';
 import { DOC_TYPE_TOOLTIPS } from '../utilities/const';
 import { getLabelColorForDocType, getDuration } from '../utilities/utils';
 import { DOC_TYPE_LABEL } from '../pages/learningCenter/const';
@@ -16,8 +16,9 @@ type DocCardBadgesProps = {
 
 const DocCardBadges: React.FC<DocCardBadgesProps> = ({ odhDoc }) => {
   const qsContext = React.useContext<QuickStartContextValues>(QuickStartContext);
-  const [inProgress, setInProgress] = React.useState<boolean>(false);
-  const [complete, setComplete] = React.useState<boolean>(false);
+  const [completionStatus, setCompletionStatus] = React.useState<
+    CompletionStatusEnum | undefined
+  >();
   const docType = odhDoc?.metadata.type as OdhDocumentType;
   const docName = odhDoc?.metadata.name;
   const duration = odhDoc?.spec.durationMinutes;
@@ -26,8 +27,7 @@ const DocCardBadges: React.FC<DocCardBadgesProps> = ({ odhDoc }) => {
     if (docType === OdhDocumentType.QuickStart && qsContext.allQuickStarts) {
       const quickStart = qsContext.allQuickStarts.find((qs) => qs.metadata.name === docName);
       if (quickStart) {
-        setInProgress(isQuickStartInProgress(quickStart.metadata.name, qsContext));
-        setComplete(isQuickStartComplete(quickStart.metadata.name, qsContext));
+        setCompletionStatus(getQuickStartCompletionStatus(quickStart.metadata.name, qsContext));
       }
     }
   }, [qsContext, docType, docName]);
@@ -44,14 +44,19 @@ const DocCardBadges: React.FC<DocCardBadgesProps> = ({ odhDoc }) => {
           {getDuration(duration)}
         </Label>
       ) : null}
-      {inProgress ? (
+      {completionStatus === CompletionStatusEnum.InProgress ? (
         <Label variant="outline" color="purple" icon={<SyncAltIcon />}>
           In Progress
         </Label>
       ) : null}
-      {complete ? (
+      {completionStatus === CompletionStatusEnum.Success ? (
         <Label variant="outline" color="green" icon={<CheckCircleIcon />}>
           Complete
+        </Label>
+      ) : null}
+      {completionStatus === CompletionStatusEnum.Failed ? (
+        <Label variant="outline" color="red" icon={<ExclamationCircleIcon />}>
+          Failed
         </Label>
       ) : null}
     </div>

--- a/frontend/src/utilities/quickStartUtils.ts
+++ b/frontend/src/utilities/quickStartUtils.ts
@@ -89,7 +89,11 @@ export const getQuickStartCompletionStatus = (
         if (status === QuickStartTaskStatus.FAILED) {
           qsStatus = CompletionStatusEnum.Failed;
         }
-        if (status === QuickStartTaskStatus.REVIEW || status === QuickStartTaskStatus.VISITED) {
+        if (
+          status === QuickStartTaskStatus.REVIEW ||
+          status === QuickStartTaskStatus.VISITED ||
+          status === QuickStartTaskStatus.INIT
+        ) {
           return CompletionStatusEnum.InProgress;
         }
         currentStep++;

--- a/frontend/src/utilities/quickStartUtils.ts
+++ b/frontend/src/utilities/quickStartUtils.ts
@@ -75,17 +75,23 @@ export const getQuickStartCompletionStatus = (
   if (!quickStartId || !qsContext || !qsContext.allQuickStartStates) {
     return undefined;
   }
+
   const quickStartState = qsContext.allQuickStartStates[quickStartId];
   if (!quickStartState || quickStartState.taskNumber === -1) {
     return undefined;
   }
 
   if (quickStartState.status === QuickStartStatus.COMPLETE) {
+    const quickStart = qsContext.allQuickStarts?.find((qs) => qs.metadata.name === quickStartId);
     let qsStatus = CompletionStatusEnum.Success,
       currentStep = 0;
-    while (quickStartState[`taskStatus${currentStep}`]) {
-      const status = quickStartState[`taskStatus${currentStep}`];
-      if (status) {
+    const tasks = quickStart?.spec.tasks;
+    if (tasks) {
+      while (currentStep < tasks.length) {
+        const status = quickStartState[`taskStatus${currentStep}`];
+        if (!status) {
+          return CompletionStatusEnum.InProgress;
+        }
         if (status === QuickStartTaskStatus.FAILED) {
           qsStatus = CompletionStatusEnum.Failed;
         }

--- a/frontend/src/utilities/quickStartUtils.ts
+++ b/frontend/src/utilities/quickStartUtils.ts
@@ -1,7 +1,7 @@
 import {
-  getQuickStartStatus,
   QuickStartContextValues,
   QuickStartStatus,
+  QuickStartTaskStatus,
 } from '@patternfly/quickstarts';
 
 export enum LaunchStatusEnum {
@@ -9,6 +9,12 @@ export enum LaunchStatusEnum {
   Continue = 'Continue',
   Restart = 'Restart',
   Close = 'Close',
+}
+
+export enum CompletionStatusEnum {
+  InProgress = 'In Progress',
+  Success = 'Success',
+  Failed = 'Failed',
 }
 
 export const getLaunchStatus = (
@@ -36,6 +42,10 @@ export const getLaunchStatus = (
     qsContext.activeQuickStartID === quickStartId ||
     quickStartState.status === QuickStartStatus.COMPLETE
   ) {
+    const taskStatus = getQuickStartCompletionStatus(quickStartId, qsContext);
+    if (taskStatus === CompletionStatusEnum.InProgress) {
+      return LaunchStatusEnum.Continue;
+    }
     return LaunchStatusEnum.Restart;
   }
 
@@ -58,28 +68,37 @@ export const getQuickStartLabel = (
   return `${launchStatus}`;
 };
 
-export const isQuickStartInProgress = (
+export const getQuickStartCompletionStatus = (
   quickStartId?: string | null,
   qsContext?: QuickStartContextValues,
-): boolean => {
+): CompletionStatusEnum | undefined => {
   if (!quickStartId || !qsContext || !qsContext.allQuickStartStates) {
-    return false;
+    return undefined;
   }
-  const launchStatus = getLaunchStatus(quickStartId, qsContext);
-
-  return launchStatus === LaunchStatusEnum.Continue;
-};
-
-export const isQuickStartComplete = (
-  quickStartId?: string | null,
-  qsContext?: QuickStartContextValues,
-): boolean => {
-  if (!quickStartId || !qsContext || !qsContext.allQuickStartStates) {
-    return false;
+  const quickStartState = qsContext.allQuickStartStates[quickStartId];
+  if (!quickStartState || quickStartState.taskNumber === -1) {
+    return undefined;
   }
-  return (
-    getQuickStartStatus(qsContext.allQuickStartStates, quickStartId) === QuickStartStatus.COMPLETE
-  );
+
+  if (quickStartState.status === QuickStartStatus.COMPLETE) {
+    let qsStatus = CompletionStatusEnum.Success,
+      currentStep = 0;
+    while (quickStartState[`taskStatus${currentStep}`]) {
+      const status = quickStartState[`taskStatus${currentStep}`];
+      if (status) {
+        if (status === QuickStartTaskStatus.FAILED) {
+          qsStatus = CompletionStatusEnum.Failed;
+        }
+        if (status === QuickStartTaskStatus.REVIEW || status === QuickStartTaskStatus.VISITED) {
+          return CompletionStatusEnum.InProgress;
+        }
+        currentStep++;
+      }
+    }
+    return qsStatus;
+  } else {
+    return CompletionStatusEnum.InProgress;
+  }
 };
 
 export const launchQuickStart = (


### PR DESCRIPTION
Fix for in progress showing up incorrectly, along with fix for not showing failed if a quick start has been completed.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s):  https://issues.redhat.com/browse/RHODS-3401 
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

1.)  Failed status test:

- Go To RHODS Dashboard > Resources
- Start a quick start
- Click on each step and set "no" to the checkbox in the "Check your work" dialog
- Click on "Close" button 
- Check the QuickStart status on the card, make sure it says Failed.

2.)  Skip step - in progress test:

- Go To RHODS Dashboard > Resources
- Start a quick start
- Skip one or more step instead of selecting "yes" or "no" in the "Check your work" dialog.
- Select on each step and set "no" or "yes" on some steps in the "Check your work" dialog
- Click on "Close" button 
- Check the QuickStart status on the card, make sure it says In Progress.
- Click continue, then go back and complete the previous skipped steps. 
- Verify that it says completed or failed based on what you selected.

- [x] The developer has manually tested the changes and verified that the changes work.
