### PR TITLE
[UPSTREAM] Fix blank dashboard when a subscription without status or installedCSV exists.

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -82,9 +82,9 @@ export type RouteKind = {
 
 // Minimal type for Subscriptions
 export type SubscriptionKind = {
-  status: {
-    installedCSV: string;
-    installPlanRef: {
+  status?: {
+    installedCSV?: string;
+    installPlanRef?: {
       namespace: string;
     };
   };

--- a/backend/src/utils/componentUtils.ts
+++ b/backend/src/utils/componentUtils.ts
@@ -169,9 +169,19 @@ const getCSVForApp = (
 
   const subscriptions = getSubscriptions();
   const appSubscription = subscriptions.find((sub) =>
-    sub.status.installedCSV.startsWith(app.spec.csvName),
+    sub.status?.installedCSV?.startsWith(app.spec.csvName),
   );
   if (!appSubscription) {
+    return Promise.resolve(undefined);
+  }
+
+  const appInstalledCSV = appSubscription.status?.installedCSV;
+  if (!appInstalledCSV) {
+    return Promise.resolve(undefined);
+  }
+
+  const namespace = appSubscription.status?.installPlanRef?.namespace;
+  if (!namespace) {
     return Promise.resolve(undefined);
   }
 
@@ -179,9 +189,9 @@ const getCSVForApp = (
     .getNamespacedCustomObject(
       'operators.coreos.com',
       'v1alpha1',
-      appSubscription.status.installPlanRef.namespace,
+      namespace,
       'clusterserviceversions',
-      appSubscription.status.installedCSV,
+      appInstalledCSV,
     )
     .then((response) => {
       const csv = response.body as CSVKind;


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-4035
- [x] The Jira story is acked
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [x] The developer has manually tested the changes and verified that the changes work.

Testing: 
Live Build: quay.io/modh/rhods-operator-live-catalog:1.11.0-rhods-4035
1. Create a bad subscription.  e.g:
```
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: bad-sub
  namespace: default
spec:
  channel: alpha
  installPlanApproval: Manual
  name: bad-sub
  source: redhat-operators
  sourceNamespace: openshift-marketplace
```
2. Restart od-dashboard pods
3. Verify Enabled and Explore tabs are populated correctly
