### PR TITLE
V1.16 build

### DIFF
--- a/backend/src/routes/api/groups-config/index.ts
+++ b/backend/src/routes/api/groups-config/index.ts
@@ -13,8 +13,13 @@ export default async (fastify: FastifyInstance): Promise<void> => {
 
   fastify.put(
     '/',
-    secureAdminRoute(fastify)(async (request: FastifyRequest<{ Body: GroupsConfig }>) => {
-      return updateGroupsConfig(fastify, request);
+    secureAdminRoute(fastify)(async (request: FastifyRequest<{ Body: GroupsConfig }>, reply) => {
+      return updateGroupsConfig(fastify, request).catch((e) => {
+        fastify.log.error(
+          `Failed to update groups configuration, ${e.response?.data?.message || e.message}`,
+        );
+        reply.status(500).send({ message: e.response?.data?.message || e.message });
+      });
     }),
   );
 };

--- a/backend/src/routes/api/health/healthUtils.ts
+++ b/backend/src/routes/api/health/healthUtils.ts
@@ -1,0 +1,13 @@
+import { KubeFastifyInstance } from '../../../types';
+import { createCustomError } from '../../../utils/requestUtils';
+
+export const health = async (fastify: KubeFastifyInstance): Promise<{ health: string }> => {
+  const kubeContext = fastify.kube?.currentContext || '';
+  if (!kubeContext && !kubeContext.trim()) {
+    const error = createCustomError('failed to get kube status', 'Failed to get Kube context', 503);
+    fastify.log.error(error, 'failed to get status');
+    throw error;
+  } else {
+    return { health: 'ok' };
+  }
+};

--- a/backend/src/routes/api/health/index.ts
+++ b/backend/src/routes/api/health/index.ts
@@ -1,0 +1,9 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { health } from './healthUtils';
+
+export default async (fastify: FastifyInstance): Promise<void> => {
+  // Unsecured route for health check
+  fastify.get('/', async (request: FastifyRequest, reply: FastifyReply) => {
+    return health(fastify);
+  });
+};

--- a/backend/src/routes/api/nb-events/index.ts
+++ b/backend/src/routes/api/nb-events/index.ts
@@ -4,13 +4,13 @@ import { secureRoute } from '../../../utils/route-security';
 
 export default async (fastify: FastifyInstance): Promise<void> => {
   fastify.get(
-    '/:namespace/:notebookName',
+    '/:namespace/:name',
     secureRoute(fastify)(
       async (
         request: FastifyRequest<{
           Params: {
             namespace: string;
-            notebookName: string;
+            name: string;
           };
           Querystring: {
             // TODO: Support server side filtering
@@ -18,8 +18,8 @@ export default async (fastify: FastifyInstance): Promise<void> => {
           };
         }>,
       ) => {
-        const params = request.params;
-        return getNotebookEvents(fastify, params.namespace, params.notebookName);
+        const { namespace, name } = request.params;
+        return getNotebookEvents(fastify, namespace, name);
       },
     ),
   );

--- a/backend/src/routes/api/notebooks/index.ts
+++ b/backend/src/routes/api/notebooks/index.ts
@@ -1,28 +1,10 @@
 import { KubeFastifyInstance, Notebook } from '../../../types';
 import { FastifyRequest } from 'fastify';
-import {
-  getNotebook,
-  getNotebooks,
-  patchNotebook,
-  createNotebook,
-  getNotebookStatus,
-} from './notebookUtils';
+import { getNotebook, patchNotebook, createNotebook, getNotebookStatus } from './notebookUtils';
 import { RecursivePartial } from '../../../typeHelpers';
 import { sanitizeNotebookForSecurity, secureRoute } from '../../../utils/route-security';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
-  fastify.get(
-    '/:namespace',
-    secureRoute(fastify)(
-      async (
-        request: FastifyRequest<{ Params: { namespace: string }; Querystring: { labels: string } }>,
-      ) => {
-        const { namespace } = request.params;
-        return await getNotebooks(fastify, namespace, request.query.labels);
-      },
-    ),
-  );
-
   fastify.get(
     '/:namespace/:name',
     secureRoute(fastify)(

--- a/backend/src/routes/api/rolebindings/index.ts
+++ b/backend/src/routes/api/rolebindings/index.ts
@@ -23,7 +23,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           );
           return rbResponse.body;
         } catch (e) {
-          fastify.log.error(`rolebinding ${rbName} could not be read, ${e}`);
+          fastify.log.error(
+            `rolebinding ${rbName} could not be read, ${e.response?.body?.message || e.message}`,
+          );
           reply.send(e);
         }
       },
@@ -45,7 +47,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           );
           return rbResponse.body;
         } catch (e) {
-          fastify.log.error(`rolebinding could not be created: ${e}`);
+          fastify.log.error(
+            `rolebinding could not be created: ${e.response?.body?.message || e.message}`,
+          );
           reply.send(e);
         }
       },

--- a/backend/src/routes/api/rolebindings/index.ts
+++ b/backend/src/routes/api/rolebindings/index.ts
@@ -47,10 +47,13 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           );
           return rbResponse.body;
         } catch (e) {
-          fastify.log.error(
-            `rolebinding could not be created: ${e.response?.body?.message || e.message}`,
-          );
-          reply.send(e);
+          if (e.response?.statusCode === 409) {
+            fastify.log.warn(`Rolebinding already present, skipping creation.`);
+            return {};
+          } else {
+            fastify.log.error(`rolebinding could not be created: ${e}`);
+            reply.send(new Error(e.response.body.message));
+          }
         }
       },
     ),

--- a/backend/src/routes/api/route/index.ts
+++ b/backend/src/routes/api/route/index.ts
@@ -1,0 +1,17 @@
+import { FastifyRequest } from 'fastify';
+import { KubeFastifyInstance } from '../../../types';
+import { secureRoute } from '../../../utils/route-security';
+import { getRoute } from '../notebooks/notebookUtils';
+
+module.exports = async (fastify: KubeFastifyInstance) => {
+  fastify.get(
+    '/:namespace/:name',
+    secureRoute(fastify)(
+      async (request: FastifyRequest<{ Params: { namespace: string; name: string } }>) => {
+        const routeName = request.params.name;
+        const namespace = request.params.namespace;
+        return getRoute(fastify, namespace, routeName);
+      },
+    ),
+  );
+};

--- a/backend/src/routes/api/secrets/index.ts
+++ b/backend/src/routes/api/secrets/index.ts
@@ -21,7 +21,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           return secretResponse.body;
         } catch (e) {
           fastify.log.error(
-            `Secret ${secretName} could not be read, ${e.response?.body || e.message || e}`,
+            `Secret ${secretName} could not be read, ${
+              e.response?.body?.message || e.message || e
+            }`,
           );
           reply.send(e);
         }
@@ -41,7 +43,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           );
           return secretResponse.body;
         } catch (e) {
-          fastify.log.error(`Secret could not be created: ${e.response?.body || e.message || e}`);
+          fastify.log.error(
+            `Secret could not be created: ${e.response?.body?.message || e.message || e}`,
+          );
           reply.send(e);
         }
       },
@@ -63,7 +67,7 @@ module.exports = async (fastify: KubeFastifyInstance) => {
         } catch (e) {
           fastify.log.error(
             `Secret ${secretRequest.metadata.name} could not be replaced: ${
-              e.response?.body || e.message || e
+              e.response?.body?.message || e.message || e
             }`,
           );
           reply.send(e);
@@ -89,7 +93,9 @@ module.exports = async (fastify: KubeFastifyInstance) => {
           return secretResponse.body;
         } catch (e) {
           fastify.log.error(
-            `Secret ${secretName} could not be deleted, ${e.response?.body || e.message || e}`,
+            `Secret ${secretName} could not be deleted, ${
+              e.response?.body?.message || e.message || e
+            }`,
           );
           reply.send(e);
         }

--- a/backend/src/routes/api/status/index.ts
+++ b/backend/src/routes/api/status/index.ts
@@ -11,8 +11,9 @@ export default async (fastify: FastifyInstance): Promise<void> => {
         .then((res) => {
           return res;
         })
-        .catch((res) => {
-          reply.send(res);
+        .catch((e) => {
+          fastify.log.error(`Failed to get status, ${e.response?.data?.message || e.message}}`);
+          reply.send(e.response?.data?.message || e.message);
         });
     }),
   );

--- a/backend/src/utils/adminUtils.ts
+++ b/backend/src/utils/adminUtils.ts
@@ -114,7 +114,9 @@ export const isUserClusterRole = async (
     const isAdminRoleBinding = checkRoleBindings(rolebinding.body, username);
     return isAdminClusterRoleBinding || isAdminRoleBinding;
   } catch (e) {
-    fastify.log.error(`Failed to list rolebindings for user, ${e}`);
+    fastify.log.error(
+      `Failed to list rolebindings for user, ${e.response?.body?.message || e.message}`,
+    );
     return false;
   }
 };

--- a/backend/src/utils/requestUtils.ts
+++ b/backend/src/utils/requestUtils.ts
@@ -6,6 +6,7 @@ export const createCustomError = (
   code = 500,
 ): createError.HttpError => {
   const error = createError(code, title);
+  error.code = code;
   error.explicitInternalServerError = code >= 500;
   error.error = title;
   error.message = message;

--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -41,7 +41,13 @@ const testAdmin = async (
   request: OauthFastifyRequest,
   needsAdmin: boolean,
 ): Promise<boolean> => {
-  const username = await getUserName(fastify, request);
+  const username = await getUserName(fastify, request).catch((error) => {
+    throw createCustomError(
+      'Error retrieving username',
+      error.response?.data?.message || error.message,
+      500,
+    );
+  });
   const { dashboardNamespace } = getNamespaces(fastify);
   const isAdmin = await isUserAdmin(fastify, username, dashboardNamespace);
   if (isAdmin) {

--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -48,12 +48,6 @@ const requestSecurityGuard = async (
 
   const isReadRequest = request.method.toLowerCase() === 'get';
 
-  // Getting a dashboard resource
-  if (isReadRequest && namespace === dashboardNamespace) {
-    // The application resources are fine to read in all cases
-    return;
-  }
-
   // Api with no name object
   if (!name && namespace === notebookNamespace && isReadRequest) {
     return;
@@ -111,8 +105,8 @@ const handleSecurityOnRouteData = async (
   const username = await getUserName(fastify, request);
   const { dashboardNamespace } = getNamespaces(fastify);
   const isAdmin = await isUserAdmin(fastify, username, dashboardNamespace);
-  if (isAdmin) {
-    // User is an admin, trust
+  if (isAdmin && !request.url.includes('secrets')) {
+    // User is an admin, trust for all but secrets
     return;
   } else if (needsAdmin && !isAdmin) {
     // Not an admin, route needs one -- reject

--- a/backend/src/utils/userUtils.ts
+++ b/backend/src/utils/userUtils.ts
@@ -39,7 +39,9 @@ export const getUser = async (
     );
     return userResponse.body as OpenShiftUser;
   } catch (e) {
-    throw new Error(`Error getting Oauth Info for user, ${e.response?.data?.message || e.message}`);
+    throw new Error(
+      `Error getting Oauth Info for user, ${e.code} - ${e.response?.data?.message || e.message}`,
+    );
   }
 };
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7834,7 +7834,7 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "optional": true
     },
     "gzip-size": {

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import '@patternfly/patternfly/patternfly.min.css';
 import '@patternfly/patternfly/patternfly-addons.css';
-import { Page } from '@patternfly/react-core';
+import { Alert, Bullseye, Page, PageSection, Spinner } from '@patternfly/react-core';
 import { detectUser } from '../redux/actions/actions';
 import { useDesktopWidth } from '../utilities/useDesktopWidth';
 import { useTrackHistory } from '../utilities/useTrackHistory';
@@ -17,11 +17,13 @@ import AppContext from './AppContext';
 
 import './App.scss';
 import { useWatchDashboardConfig } from 'utilities/useWatchDashboardConfig';
+import { useUser } from '../redux/selectors';
 
 const App: React.FC = () => {
   const isDeskTop = useDesktopWidth();
   const [isNavOpen, setIsNavOpen] = React.useState(isDeskTop);
   const [notificationsOpen, setNotificationsOpen] = React.useState(false);
+  const { username, userError } = useUser();
   const dispatch = useDispatch();
   useSegmentTracking();
   useTrackHistory();
@@ -40,6 +42,30 @@ const App: React.FC = () => {
   const onNavToggle = () => {
     setIsNavOpen(!isNavOpen);
   };
+
+  if (!username) {
+    // We do not have the data yet for who they are, we can't show the app. If we allow anything
+    // to render right now, the username is going to be blank and we won't know permissions
+    if (userError) {
+      // We likely don't have a username still so just show the error
+      return (
+        <Page>
+          <PageSection>
+            <Alert variant="danger" isInline title="General loading error">
+              {userError.message}
+            </Alert>
+          </PageSection>
+        </Page>
+      );
+    }
+
+    // Assume we are still waiting on the API to finish
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
 
   return (
     <AppContext.Provider

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -2,7 +2,16 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import '@patternfly/patternfly/patternfly.min.css';
 import '@patternfly/patternfly/patternfly-addons.css';
-import { Alert, Bullseye, Page, PageSection, Spinner } from '@patternfly/react-core';
+import {
+  Alert,
+  Bullseye,
+  Button,
+  Page,
+  PageSection,
+  Spinner,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import { detectUser } from '../redux/actions/actions';
 import { useDesktopWidth } from '../utilities/useDesktopWidth';
 import { useTrackHistory } from '../utilities/useTrackHistory';
@@ -18,6 +27,7 @@ import AppContext from './AppContext';
 import './App.scss';
 import { useWatchDashboardConfig } from 'utilities/useWatchDashboardConfig';
 import { useUser } from '../redux/selectors';
+import { logout } from './appUtils';
 
 const App: React.FC = () => {
   const isDeskTop = useDesktopWidth();
@@ -44,16 +54,28 @@ const App: React.FC = () => {
   };
 
   if (!username) {
-    // We do not have the data yet for who they are, we can't show the app. If we allow anything
-    // to render right now, the username is going to be blank and we won't know permissions
+    // We lack the critical data to startup the app
     if (userError) {
-      // We likely don't have a username still so just show the error
+      // There was an error fetching critical data
       return (
         <Page>
           <PageSection>
-            <Alert variant="danger" isInline title="General loading error">
-              {userError.message}
-            </Alert>
+            <Stack hasGutter>
+              <StackItem>
+                <Alert variant="danger" isInline title="General loading error">
+                  <p>{userError.message || 'Unknown error occurred during startup.'}</p>
+                  <p>Logging out and logging back in may solve the issue.</p>
+                </Alert>
+              </StackItem>
+              <StackItem>
+                <Button
+                  variant="secondary"
+                  onClick={() => logout().then(() => window.location.reload())}
+                >
+                  Logout
+                </Button>
+              </StackItem>
+            </Stack>
           </PageSection>
         </Page>
       );

--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -15,6 +15,7 @@ import { COMMUNITY_LINK, DOC_LINK, SUPPORT_LINK } from '../utilities/const';
 import { AppNotification, State } from '../redux/types';
 import { useWatchDashboardConfig } from '../utilities/useWatchDashboardConfig';
 import AppLauncher from './AppLauncher';
+import { logout } from './appUtils';
 
 interface HeaderToolsProps {
   onNotificationsClick: () => void;
@@ -35,10 +36,10 @@ const HeaderTools: React.FC<HeaderToolsProps> = ({ onNotificationsClick }) => {
 
   const handleLogout = () => {
     setUserMenuOpen(false);
-    fetch('/oauth/sign_out')
-      .then(() => console.log('logged out'))
-      .catch((err) => console.error(err))
-      .finally(() => window.location.reload());
+    logout().then(() => {
+      console.log('logged out');
+      window.location.reload();
+    });
   };
 
   const userMenuItems = [

--- a/frontend/src/app/appUtils.ts
+++ b/frontend/src/app/appUtils.ts
@@ -1,0 +1,3 @@
+export const logout = (): Promise<unknown> => {
+  return fetch('/oauth/sign_out').catch((err) => console.error('Error logging out', err));
+};

--- a/frontend/src/pages/notebookController/SetupCurrentNotebook.tsx
+++ b/frontend/src/pages/notebookController/SetupCurrentNotebook.tsx
@@ -18,7 +18,7 @@ const SetupCurrentNotebook: React.FC<SetupCurrentNotebookProps> = ({
 }) => {
   const { notebookNamespace } = useNamespaces();
   const { user: username } = useSpecificNotebookUserState(currentNotebook ?? null);
-  const { notebooks, loaded, loadError, forceRefresh } = useWatchNotebooksForUsers(
+  const { notebooks, loaded, loadError, forceRefresh, setPollInterval } = useWatchNotebooksForUsers(
     notebookNamespace,
     [username],
   );
@@ -34,10 +34,20 @@ const SetupCurrentNotebook: React.FC<SetupCurrentNotebookProps> = ({
         ...prevState,
         current: notebook,
         currentIsRunning: isCurrentlyRunning,
-        requestRefresh: forceRefresh,
+        requestRefresh: (speed?: number) => {
+          forceRefresh();
+          setPollInterval(speed);
+        },
       }));
     }
-  }, [notebook, currentNotebook, forceRefresh, setNotebookState, isCurrentlyRunning]);
+  }, [
+    notebook,
+    currentNotebook,
+    forceRefresh,
+    setNotebookState,
+    isCurrentlyRunning,
+    setPollInterval,
+  ]);
 
   if (currentNotebook === undefined || loadError) {
     return (

--- a/frontend/src/pages/notebookController/notebookControllerContextTypes.ts
+++ b/frontend/src/pages/notebookController/notebookControllerContextTypes.ts
@@ -6,8 +6,11 @@ import { SetCurrentAdminTab } from './useAdminTabState';
 export type NotebookControllerContextProps = {
   /** Current user's notebook -- set internally */
   currentUserNotebook: Notebook | null;
-  /** Requests the notebook be re-fetched now instead of waiting for polling intervals */
-  requestNotebookRefresh: () => void;
+  /**
+   * Requests the notebook be re-fetched now instead of waiting for polling intervals.
+   * The provided speed will change the cadence future fetches are done at. Omit to reset.
+   */
+  requestNotebookRefresh: (changeSpeed?: number) => void;
   /** Status on if the current notebook is in a state we can consider it running */
   currentUserNotebookIsRunning: boolean;
 

--- a/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
+++ b/frontend/src/pages/notebookController/screens/server/NotebookServer.tsx
@@ -7,11 +7,13 @@ import { NotebookControllerContext } from '../../NotebookControllerContext';
 import ImpersonateAlert from '../admin/ImpersonateAlert';
 import NotebookServerDetails from './NotebookServerDetails';
 import StopServerModal from './StopServerModal';
+import useNotification from '../../../../utilities/useNotification';
 
 import '../../NotebookController.scss';
 
 export const NotebookServer: React.FC = () => {
   const history = useHistory();
+  const notification = useNotification();
   const {
     currentUserNotebook: notebook,
     currentUserNotebookIsRunning,
@@ -57,6 +59,11 @@ export const NotebookServer: React.FC = () => {
                   onClick={() => {
                     if (notebook.metadata.annotations?.['opendatahub.io/link']) {
                       window.location.href = notebook.metadata.annotations['opendatahub.io/link'];
+                    } else {
+                      notification.error(
+                        'Error accessing notebook server',
+                        'Failed to redirect page due to missing notebook URL, please try to refresh the page and try it again.',
+                      );
                     }
                   }}
                 >

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -252,19 +252,18 @@ const SpawnerPage: React.FC = React.memo(() => {
     const envVarFileName = generateEnvVarFileNameFromUsername(username);
     const envVars = classifyEnvVars(variableRows);
     await Promise.all([
-      () =>
-        new Promise((resolve, reject) => {
-          const requestedPvcSize = dashboardConfig.spec.notebookController?.pvcSize;
-          const pvcBody = generatePvc(pvcName, projectName, requestedPvcSize ?? DEFAULT_PVC_SIZE);
-          verifyResource(pvcName, projectName, getPvc, createPvc, pvcBody)
-            .then(() => {
-              resolve([]);
-            })
-            .catch((e) => {
-              console.error(`Something wrong with PVC ${pvcName}: ${e}`);
-              reject();
-            });
-        }),
+      new Promise<void>((resolve, reject) => {
+        const requestedPvcSize = dashboardConfig.spec.notebookController?.pvcSize;
+        const pvcBody = generatePvc(pvcName, projectName, requestedPvcSize ?? DEFAULT_PVC_SIZE);
+        verifyResource(pvcName, projectName, getPvc, createPvc, pvcBody)
+          .then(() => {
+            resolve();
+          })
+          .catch((e) => {
+            console.error(`Something wrong with PVC ${pvcName}: ${e}`);
+            reject();
+          });
+      }),
       verifyEnvVars(
         envVarFileName,
         projectName,

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -64,7 +64,7 @@ const SpawnerPage: React.FC = React.memo(() => {
   const { notebookNamespace: projectName } = useNamespaces();
   const currentUserState = useNotebookUserState();
   const username = currentUserState.user;
-  const [startShown, setStartShown] = useSpawnerNotebookModalState();
+  const { startShown, hideStartShown, refreshNotebookForStart } = useSpawnerNotebookModalState();
   const [selectedImageTag, setSelectedImageTag] = React.useState<ImageTag>({
     image: undefined,
     tag: undefined,
@@ -270,13 +270,11 @@ const SpawnerPage: React.FC = React.memo(() => {
     })
       .then(() => {
         fireStartServerEvent();
-        return true;
       })
       .catch((e) => {
         setSubmitError(e);
-        return false;
       });
-    requestNotebookRefresh();
+    refreshNotebookForStart();
   };
 
   return (
@@ -338,7 +336,7 @@ const SpawnerPage: React.FC = React.memo(() => {
                 onClick={() => {
                   handleNotebookAction().catch((e) => {
                     setCreateInProgress(false);
-                    setStartShown(false);
+                    hideStartShown();
                     console.error(e);
                   });
                 }}
@@ -371,7 +369,7 @@ const SpawnerPage: React.FC = React.memo(() => {
                 .catch((e) => notification.error(`Error stop notebook ${notebookName}`, e.message));
             } else {
               // Shouldn't happen, but if we don't have a notebook, there is nothing to stop
-              setStartShown(false);
+              hideStartShown();
             }
             setCreateInProgress(false);
           }}

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -312,6 +312,7 @@ const SpawnerPage: React.FC = React.memo(() => {
         })
         .catch((e) => {
           setSubmitError(e);
+          setCreateInProgress(false);
           // We had issues spawning the notebook -- try to stop it
           stopNotebook(projectName, notebookName).catch(() =>
             notification.error(

--- a/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
@@ -19,6 +19,7 @@ import { NotebookControllerContext } from '../../NotebookControllerContext';
 import '../../NotebookController.scss';
 
 type StartServerModalProps = {
+  spawnInProgress: boolean;
   open: boolean;
   onClose: () => void;
 };
@@ -29,29 +30,23 @@ type SpawnStatus = {
   description: React.ReactNode;
 };
 
-const StartServerModal: React.FC<StartServerModalProps> = ({ open, onClose }) => {
+const StartServerModal: React.FC<StartServerModalProps> = ({ open, spawnInProgress, onClose }) => {
   const { currentUserNotebook: notebook, currentUserNotebookIsRunning: isNotebookRunning } =
     React.useContext(NotebookControllerContext);
-  const spawnInProgress = open;
   const [logsExpanded, setLogsExpanded] = React.useState<boolean>(false);
   const [spawnPercentile, setSpawnPercentile] = React.useState<number>(0);
   const [spawnStatus, setSpawnStatus] = React.useState<SpawnStatus | null>(null);
   const [unstableNotebookStatus, events] = useNotebookStatus(spawnInProgress);
   const notebookStatus = useDeepCompareMemoize(unstableNotebookStatus);
 
-  const onBeforeClose = () => {
-    // Notify
-    onClose();
-  };
   React.useEffect(() => {
-    // TODO: Improve this, hack to just not update the modal while it is open
-    if (!spawnInProgress && (spawnPercentile || spawnStatus)) {
+    if (!open) {
       // Reset the modal
       setLogsExpanded(false);
       setSpawnPercentile(0);
       setSpawnStatus(null);
     }
-  }, [spawnInProgress, spawnPercentile, spawnStatus]);
+  }, [open]);
 
   const notebookLink = notebook?.metadata.annotations?.['opendatahub.io/link'];
 
@@ -120,18 +115,15 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, onClose }) =>
     }
 
     const currentEvent = notebookStatus?.currentEvent;
-    return (
-      <Progress
-        id="progress-bar"
-        value={spawnPercentile}
-        title={
-          events.length > 0 && currentEvent
-            ? currentEvent
-            : 'Waiting for server request to start...'
-        }
-        variant={variant}
-      />
-    );
+    let title: string;
+    if (events.length > 0 && currentEvent) {
+      title = currentEvent;
+    } else if (open && !spawnInProgress) {
+      title = 'Creating resources...';
+    } else {
+      title = 'Waiting for server request to start...';
+    }
+    return <Progress id="progress-bar" value={spawnPercentile} title={title} variant={variant} />;
   };
 
   const renderStatus = () => {
@@ -147,7 +139,12 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, onClose }) =>
 
   const renderButtons = () =>
     !isNotebookRunning ? (
-      <Button key="cancel" variant={spawnFailed ? 'primary' : 'secondary'} onClick={onBeforeClose}>
+      <Button
+        key="cancel"
+        variant={spawnFailed ? 'primary' : 'secondary'}
+        onClick={onClose}
+        isDisabled={!open}
+      >
         {spawnFailed ? 'Close' : 'Cancel'}
       </Button>
     ) : null;
@@ -180,7 +177,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ open, onClose }) =>
       title="Starting server"
       isOpen={open}
       showClose={spawnFailed}
-      onClose={onBeforeClose}
+      onClose={onClose}
     >
       {renderProgress()}
       {renderStatus()}

--- a/frontend/src/services/routeService.ts
+++ b/frontend/src/services/routeService.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+import { Route } from '../types';
+
+export const getRoute = (namespace: string, routeName: string): Promise<Route> => {
+  const url = `/api/route/${namespace}/${routeName}`;
+  return axios.get(url).then((response) => {
+    return response.data;
+  });
+};

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { AxiosError } from 'axios';
-import {
-  createConfigMap,
-  deleteConfigMap,
-  getConfigMap,
-  replaceConfigMap,
-} from '../services/configMapService';
-import { createSecret, deleteSecret, getSecret, replaceSecret } from '../services/secretsService';
 import { createRoleBinding, getRoleBinding } from '../services/roleBindingService';
 import {
-  EnvVarReducedType,
   EnvVarReducedTypeKeyValues,
   EnvVarResource,
   EnvVarResourceType,
@@ -153,37 +145,6 @@ export const verifyEnvVars = async (
   if (!_.isEqual(response?.data, envVars)) {
     await replaceFunc(newResource);
   }
-};
-
-/** Update the config map and secret file on the cluster */
-export const checkEnvVarFile = async (
-  username: string,
-  namespace: string,
-  variableRows: VariableRow[],
-): Promise<EnvVarReducedType> => {
-  const envVarFileName = generateEnvVarFileNameFromUsername(username);
-  const envVars = classifyEnvVars(variableRows);
-  await verifyEnvVars(
-    envVarFileName,
-    namespace,
-    EnvVarResourceType.Secret,
-    envVars.secrets,
-    getSecret,
-    createSecret,
-    replaceSecret,
-    deleteSecret,
-  );
-  await verifyEnvVars(
-    envVarFileName,
-    namespace,
-    EnvVarResourceType.ConfigMap,
-    envVars.configMap,
-    getConfigMap,
-    createConfigMap,
-    replaceConfigMap,
-    deleteConfigMap,
-  );
-  return { envVarFileName, ...envVars };
 };
 
 export const generatePvc = (

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -26,6 +26,7 @@ import { EMPTY_USER_STATE } from '../pages/notebookController/const';
 import { useDeepCompareMemoize } from './useDeepCompareMemoize';
 import { useWatchNotebookEvents } from './useWatchNotebookEvents';
 import useNamespaces from '../pages/notebookController/useNamespaces';
+import { getRoute } from '../services/routeService';
 
 export const usernameTranslate = (username: string): string => {
   const encodedUsername = encodeURIComponent(username);
@@ -277,6 +278,59 @@ const useLastOpenTime = (open: boolean): Date | null => {
   }
 
   return ref.current;
+};
+
+export const useNotebookRedirectLink = (): (() => Promise<string>) => {
+  const { currentUserNotebook } = React.useContext(NotebookControllerContext);
+  const { notebookNamespace } = useNamespaces();
+  const fetchCountRef = React.useRef(5); // how many tries to get the Route
+
+  const routeName = currentUserNotebook?.metadata.name;
+  const backupRoute = currentUserNotebook?.metadata.annotations?.['opendatahub.io/link'];
+
+  return React.useCallback((): Promise<string> => {
+    if (backupRoute) {
+      // TODO: look to remove this in the future to stop relying on backend annotation
+      // We already have our backup code's route, use it
+      return Promise.resolve(backupRoute);
+    }
+
+    if (!routeName) {
+      // At time of call, if we do not have a route name, we are too late
+      // This should *never* happen, somehow the modal got here before the Notebook had a name!?
+      console.error('Unable to determine why there was no route -- notebook did not have a name');
+      return Promise.reject();
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const call = (resolve, reject) => {
+        getRoute(notebookNamespace, routeName)
+          .then((route) => {
+            resolve(`https://${route.spec.host}/notebook/${notebookNamespace}/${routeName}`);
+          })
+          .catch((e) => {
+            if (backupRoute) {
+              resolve(backupRoute);
+              return;
+            }
+            console.warn('Unable to get the route. Re-polling.', e);
+            if (fetchCountRef.current <= 0) {
+              fetchCountRef.current--;
+              setTimeout(() => call(resolve, reject), 1000);
+            } else {
+              reject();
+            }
+          });
+      };
+
+      call(resolve, () => {
+        console.error(
+          'Could not fetch route over several tries, See previous warnings for a history of why each failed call.',
+        );
+        reject();
+      });
+    });
+  }, [backupRoute, notebookNamespace, routeName]);
 };
 
 export const useNotebookStatus = (

--- a/frontend/src/utilities/useWatchDashboardConfig.tsx
+++ b/frontend/src/utilities/useWatchDashboardConfig.tsx
@@ -3,7 +3,7 @@ import { DashboardConfig } from '../types';
 import { POLL_INTERVAL } from './const';
 import { useDeepCompareMemoize } from './useDeepCompareMemoize';
 import { fetchDashboardConfig } from '../services/dashboardConfigService';
-import { logout } from './appUtils';
+import { logout } from '../app/appUtils';
 
 export const blankDashboardCR: DashboardConfig = {
   apiVersion: 'opendatahub.io/v1alpha',

--- a/frontend/src/utilities/useWatchNotebooksForUsers.tsx
+++ b/frontend/src/utilities/useWatchNotebooksForUsers.tsx
@@ -14,7 +14,7 @@ const useWatchNotebooksForUsers = (
   loaded: boolean;
   loadError: Error | undefined;
   forceRefresh: (usernames?: string[]) => void;
-  setPollInterval: (interval: number) => void;
+  setPollInterval: (interval?: number) => void;
 } => {
   const usernames = useDeepCompareMemoize(listOfUsers);
   const [loaded, setLoaded] = React.useState<boolean>(false);
@@ -75,6 +75,10 @@ const useWatchNotebooksForUsers = (
     [getNotebooks, usernames],
   );
 
+  const setPollIntervalSafe = React.useCallback((newPollInterval?: number) => {
+    setPollInterval(newPollInterval ?? POLL_INTERVAL);
+  }, []);
+
   React.useEffect(() => {
     getNotebooks(usernames);
     const watchHandle = setInterval(() => getNotebooks(usernames), pollInterval);
@@ -86,7 +90,7 @@ const useWatchNotebooksForUsers = (
     };
   }, [pollInterval, getNotebooks, usernames]);
 
-  return { notebooks, loaded, loadError, forceRefresh, setPollInterval };
+  return { notebooks, loaded, loadError, forceRefresh, setPollInterval: setPollIntervalSafe };
 };
 
 export default useWatchNotebooksForUsers;

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -39,10 +39,8 @@ spec:
             cpu: 1000m
             memory: 2Gi
         livenessProbe:
-          httpGet:
-            path: /api/config
+          tcpSocket:
             port: 8080
-            scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 15
           periodSeconds: 30
@@ -50,7 +48,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /api/config
+            path: /api/health
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 30


### PR DESCRIPTION
## [API vulnerability allows unprivileged users to access secrets - RHODS-5134](https://issues.redhat.com/browse/RHODS-5134)

* [Add Route Security to some routes](https://github.com/opendatahub-io/odh-dashboard/pull/488) 
* [Fix issue with requesting kube resources](https://github.com/opendatahub-io/odh-dashboard/pull/501)
* [Secure all routes](https://github.com/opendatahub-io/odh-dashboard/pull/502)
* [Secure nb-events endpoint](https://github.com/opendatahub-io/odh-dashboard/pull/510)
* [Update the logic of getting and patching the route for notebook](https://github.com/opendatahub-io/odh-dashboard/pull/516/files)
* [Don't blanket allow reading of dashboard namespace](https://github.com/opendatahub-io/odh-dashboard/pull/519) 
* [Improve Admin Access & Disallow Outside Namespaces](https://github.com/opendatahub-io/odh-dashboard/pull/524)
* [Improve Admin Access & Disallow Outside Namespaces](https://github.com/opendatahub-io/odh-dashboard/pull/529)
* [Update liveness/readiness probe with an endpoint without auth](https://github.com/opendatahub-io/odh-dashboard/pull/543)

## [Randomly logged in as kube:admin to RHODS dashboard - RHODS-5099](https://issues.redhat.com/browse/RHODS-5099)

* [Remove logic - kube:admin as default username](https://github.com/opendatahub-io/odh-dashboard/pull/498)

## [Error validating the rolebinding of your notebook - RHODS-5127](https://issues.redhat.com/browse/RHODS-5127)

* [Ignore 409 case for RBs](https://github.com/opendatahub-io/odh-dashboard/pull/499)

## [Dashboard fails to redirect to the Notebook under load pressure - RHODS-5128](https://issues.redhat.com/browse/RHODS-5128)

* [Update the logic of getting and patching the route for notebook](https://github.com/opendatahub-io/odh-dashboard/pull/516)

## [Failed to redirect: notebooks not annotated - RHODS-5129](https://issues.redhat.com/browse/RHODS-5129)

* [Update the logic of getting and patching the route for notebook](https://github.com/opendatahub-io/odh-dashboard/pull/516)

## [Notebook "Server Starting" popup not visible 15s after click on Start Server - RHODS-5150](https://issues.redhat.com/browse/RHODS-5150)

* [Improve the Start Modal Opening](https://github.com/opendatahub-io/odh-dashboard/pull/521)
* [Improve Spawner Speed by Batching Requests](https://github.com/opendatahub-io/odh-dashboard/pull/541)

## [Notebook not available after the redirection - RHODS-5151](https://issues.redhat.com/browse/RHODS-5151)

* [Check notebook status by container statuses instead of pod phase](https://github.com/opendatahub-io/odh-dashboard/pull/520)

## [KFNBC Reloading the page always displays an error for a split second - RHODS-5184](https://issues.redhat.com/browse/RHODS-5184)

* [Check notebook status by container statuses instead of pod phase](https://github.com/opendatahub-io/odh-dashboard/pull/447)
