### PR TITLE
[UPSTREAM] Add dynamic spec to servingruntime objects

### DIFF
--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -247,6 +247,8 @@ export type ServingRuntimeKind = K8sResourceCommon & {
     builtInAdapter: {
       serverType: string;
       runtimeManagementPort: number;
+      memBufferBytes?: number;
+      modelLoadingTimeoutMillis?: number;
     };
     containers: {
       args: string[];

--- a/frontend/src/pages/modelServing/screens/const.ts
+++ b/frontend/src/pages/modelServing/screens/const.ts
@@ -1,3 +1,4 @@
+import { ServingRuntimeKind } from 'k8sTypes';
 import { ServingRuntimeSize } from './types';
 
 export const DEFAULT_MODEL_SERVER_SIZES: ServingRuntimeSize[] = [
@@ -56,3 +57,67 @@ export const STORAGE_KEYS_REQUIRED: STORAGE_KEYS[] = [
   STORAGE_KEYS.SECRET_ACCESS_KEY,
   STORAGE_KEYS.S3_ENDPOINT,
 ];
+
+export const DEFAULT_MODEL_SERVING_TEAMPLATE: ServingRuntimeKind = {
+  apiVersion: 'serving.kserve.io/v1alpha1',
+  kind: 'ServingRuntime',
+  metadata: {
+    name: '',
+    namespace: '',
+    labels: {
+      name: '',
+      'opendatahub.io/dashboard': 'true',
+    },
+    annotations: {},
+  },
+  spec: {
+    supportedModelFormats: [
+      {
+        name: 'openvino_ir',
+        version: 'opset1',
+        autoSelect: true,
+      },
+      {
+        name: 'onnx',
+        version: '1',
+        autoSelect: true,
+      },
+    ],
+    replicas: 1,
+    protocolVersions: ['grpc-v1'],
+    multiModel: true,
+    grpcEndpoint: 'port:8085',
+    grpcDataEndpoint: 'port:8001',
+    containers: [
+      {
+        name: 'ovms',
+        image:
+          'registry.redhat.io/rhods/odh-openvino-servingruntime-rhel8@sha256:7ef272bc7be866257b8126620e139d6e915ee962304d3eceba9c9d50d4e79767',
+        args: [
+          '--port=8001',
+          '--rest_port=8888',
+          '--config_path=/models/model_config_list.json',
+          '--file_system_poll_wait_seconds=0',
+          '--grpc_bind_address=127.0.0.1',
+          '--rest_bind_address=127.0.0.1',
+        ],
+        resources: {
+          requests: {
+            cpu: '0',
+            memory: '0',
+          },
+          limits: {
+            cpu: '0',
+            memory: '0',
+          },
+        },
+      },
+    ],
+    builtInAdapter: {
+      serverType: 'ovms',
+      runtimeManagementPort: 8888,
+      memBufferBytes: 134217728,
+      modelLoadingTimeoutMillis: 90000,
+    },
+  },
+};

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -35,6 +35,7 @@ import ServingRuntimeReplicaSection from './ServingRuntimeReplicaSection';
 import ServingRuntimeSizeSection from './ServingRuntimeSizeSection';
 import ServingRuntimeTokenSection from './ServingRuntimeTokenSection';
 import { translateDisplayNameForK8s } from 'pages/projects/utils';
+import { useDashboardNamespace } from 'redux/selectors';
 
 type ManageServingRuntimeModalProps = {
   isOpen: boolean;
@@ -56,6 +57,9 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
   const [error, setError] = React.useState<Error | undefined>();
 
   const { currentProject } = React.useContext(ProjectDetailsContext);
+
+  const { dashboardNamespace } = useDashboardNamespace();
+
   const namespace = currentProject.metadata.name;
 
   const tokenErrors = createData.tokens.filter((token) => token.error !== '').length > 0;
@@ -168,7 +172,7 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
         ...(currentProject.metadata.labels?.['modelmesh-enabled']
           ? [addSupportModelMeshProject(currentProject.metadata.name)]
           : []),
-        createServingRuntime(createData, namespace),
+        createServingRuntime(createData, dashboardNamespace, namespace),
         enableTokenAuth(),
       ])
         .then(() => {

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -5,6 +5,7 @@ commonLabels:
   app.kubernetes.io/part-of: odh-dashboard
 bases:
   - ../apps
+  - ../modelserving
 resources:
 - role.yaml
 - cluster-role.yaml
@@ -19,6 +20,8 @@ resources:
 - oauth.secret.yaml
 - fetch-builds-and-images.rbac.yaml
 - image-puller.clusterrolebinding.yaml
+- model-serving-role.yaml
+- model-serving-role-binding.yaml
 images:
 - name: odh-dashboard
   newName: quay.io/opendatahub/odh-dashboard

--- a/manifests/base/model-serving-role-binding.yaml
+++ b/manifests/base/model-serving-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name:  servingruntimes-config-updater
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: servingruntimes-config-updater

--- a/manifests/base/model-serving-role.yaml
+++ b/manifests/base/model-serving-role.yaml
@@ -1,0 +1,13 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: servingruntimes-config-updater
+rules:
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+    resourceNames:
+      - servingruntimes-config

--- a/manifests/modelserving/kustomization.yaml
+++ b/manifests/modelserving/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: odh-dashboard
+  app.kubernetes.io/part-of: odh-dashboard
+resources:
+  -  servingruntimes-config.yaml

--- a/manifests/modelserving/servingruntimes-config.yaml
+++ b/manifests/modelserving/servingruntimes-config.yaml
@@ -1,0 +1,55 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: servingruntimes-config
+data:
+  default-config: |
+    apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      # metadata will be overwritten by the model's metadata
+      name: ''
+      namespace: ''
+      labels:
+        name: ''
+        opendatahub.io/dashboard: 'true'
+      annotations: {}
+    spec:
+      supportedModelFormats:
+        - name: openvino_ir
+          version: opset1
+          autoSelect: true
+        - name: onnx
+          version: '1'
+          autoSelect: true
+      # replicas will be overwritten by the model's replica
+      replicas: 1
+      protocolVersions:
+        - grpc-v1
+      multiModel: true
+      grpcEndpoint: 'port:8085'
+      grpcDataEndpoint: 'port:8001'
+      containers:
+        - name: ovms
+          image: >-
+            registry.redhat.io/rhods/odh-openvino-servingruntime-rhel8@sha256:7ef272bc7be866257b8126620e139d6e915ee962304d3eceba9c9d50d4e79767
+          args:
+            - '--port=8001'
+            - '--rest_port=8888'
+            - '--config_path=/models/model_config_list.json'
+            - '--file_system_poll_wait_seconds=0'
+            - '--grpc_bind_address=127.0.0.1'
+            - '--rest_bind_address=127.0.0.1'
+          resources:
+            # resources will be overwritten by the model's resource
+            requests:
+              cpu: 1
+              memory: 2
+            limits:
+              cpu: 1
+              memory: 2
+      builtInAdapter:
+        serverType: ovms
+        runtimeManagementPort: 8888
+        memBufferBytes: 134217728
+        modelLoadingTimeoutMillis: 90000


### PR DESCRIPTION
## Description

Add role for servingruntime configmap for https://issues.redhat.com/browse/RHODS-6330

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-6330 
- [X] Live build image: [quay.io/rmartine/rhods-operator-live-catalog:1.22.0-1](http://quay.io/rmartine/rhods-operator-live-catalog:1.22.0-1)
- [X] The Jira story is acked
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Deploy all the files in the manifest folder
2. Create a new Model Server
3. Check that the ServingRuntime is created with the specification of the `servingruntimes-config` ConfigMap.
4. Now use #806 to fake a regular user.
5. Repeate the same process
6. Ensure regular user with no read options can access the manifest too
