### PR TITLE
[RHOAIENG-8521] Enable home page in manifest file

### DIFF
--- a/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/overlays/odhdashboardconfig/odhdashboardconfig.yaml
@@ -13,7 +13,7 @@ spec:
     disableSupport: false
     disableTracking: false
     enablement: true
-    disableHome: true
+    disableHome: false
     disableProjects: false
     disablePipelines: false
     disableModelServing: false


### PR DESCRIPTION
Fixes: [RHOAIENG-8521](https://issues.redhat.com/browse/RHOAIENG-8521)

## Description
Updates the dashboard config manifest file to enable the home page by default.
