### PR TITLE
(cherry-picked) Broken link to Fraud Detection tutorial in Dashboard Home (RHOAI 2.11.0)

### DIFF
--- a/manifests/overlays/apps/base/rhoai/rhoai-docs.yaml
+++ b/manifests/overlays/apps/base/rhoai/rhoai-docs.yaml
@@ -10,7 +10,7 @@ spec:
   type: tutorial
   description: |-
     Use OpenShift AI to train an example model in a Jupyter notebook, deploy the model, integrate the model into a fraud detection application, and refine the model by using automated pipelines.
-  url: https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_cloud-service/1/html-single/openshift_ai_tutorial_-_fraud_detection_example/
+  url: https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_cloud_service/1/html-single/openshift_ai_tutorial_-_fraud_detection_example/
   durationMinutes: 60
 ---
 apiVersion: dashboard.opendatahub.io/v1
@@ -20,7 +20,7 @@ metadata:
     opendatahub.io/categories: 'Getting started,Model training,Notebook environments,Pipelines'
   name: rhoai-documentation
 spec:
-  displayName:  Red Hat OpenShift AI
+  displayName: Red Hat OpenShift AI
   type: documentation
   appName: rhoai
   description: |-
@@ -44,3 +44,4 @@ spec:
     fill="#fff" stroke-width="0"/></g></svg>
   provider: Red Hat
 ---
+


### PR DESCRIPTION
Closes: [RHOAIENG-9175](https://issues.redhat.com/browse/RHOAIENG-9175)

## Description
Change the link in manifest file for Fraud Detection tutorial

https://github.com/opendatahub-io/odh-dashboard/assets/97534722/b15b1853-2701-4837-a28c-591d69e4d3e5


## How Has This Been Tested?
1. Deploy the manifest `oc apply -k manifests/overlays/apps/base/rhoai -n opendatahub`
2. Verify that the link redirects to the correct destination.

## Test Impact
None, just a URL change.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
