### PR TITLE
Upversion Dashboard (#3037) (#3043)

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -8,4 +8,4 @@ ODH_FAVICON=odh-favicon.svg
 ODH_NOTEBOOK_REPO=opendatahub
 
 ########## Change this version with each dashboard release ###########
-INTERNAL_DASHBOARD_VERSION=v2.24.0
+INTERNAL_DASHBOARD_VERSION=v2.25.0


### PR DESCRIPTION
Catchup -- just the version number, used in segment. CI problems on Friday prevented this from getting in.