### PR TITLE
enable connection types

### DIFF
--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -64,7 +64,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableDistributedWorkloads: false,
       disableModelRegistry: false,
       disableServingRuntimeParams: false,
-      disableConnectionTypes: true,
+      disableConnectionTypes: false,
       disableStorageClasses: false,
       disableNIMModelServing: true,
     },

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -30,14 +30,13 @@ The following are a list of features that are supported, along with there defaul
 | disableKServeMetrics         | false   | Disables the ability to see KServe Metrics.                                                          |
 | disableModelMesh             | false   | Disables the ability to select ModelMesh as a Serving Platform.                                      |
 | disableAcceleratorProfiles   | false   | Disables Accelerator profiles from the Admin Panel.                                                  |
-| disableTrustyBiasMetrics           | false   | Disables Model Bias tab from Model Serving metrics.                                                  |
+| disableTrustyBiasMetrics     | false   | Disables Model Bias tab from Model Serving metrics.                                                  |
 | disablePerformanceMetrics    | false   | Disables Endpoint Performance tab from Model Serving metrics.                                        |
 | disableDistributedWorkloads  | false   | Disables Distributed Workload Metrics from the dashboard.                                            |
 | disableModelRegistry         | false   | Disables Model Registry from the dashboard.                                                          |
-| disableServingRuntimeParams  | false    | Disables Serving Runtime params from the dashboard.                                                  |
-| disableConnectionTypes       | true    | Disables creating custom data connection types from the dashboard.                                   |
-| disableStorageClasses        | false    | Disables storage classes settings nav item from the dashboard.                                       |
-| disableNIMModelServing       | true    | Disables components of NIM Model UI from the dashboard.   
+| disableServingRuntimeParams  | false   | Disables Serving Runtime params from the dashboard.                                                  |
+| disableStorageClasses        | false   | Disables storage classes settings nav item from the dashboard.                                       |
+| disableNIMModelServing       | true    | Disables components of NIM Model UI from the dashboard.                                              |
 
 ## Defaults
 
@@ -66,7 +65,6 @@ spec:
     disableTrustyBiasMetrics: false
     disablePerformanceMetrics: false
     disableDistributedWorkloads: false
-    disableConnectionTypes: false
     disableStorageClasses: false
     disableNIMModelServing: true
 ```

--- a/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/connections/ConnectionsFormSection.tsx
@@ -20,6 +20,7 @@ import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTyp
 import {
   filterEnabledConnectionTypes,
   getConnectionTypeDisplayName,
+  isConnection,
 } from '~/concepts/connectionTypes/utils';
 import { useWatchConnectionTypes } from '~/utilities/useWatchConnectionTypes';
 import { useNotebooksStates } from '~/pages/projects/notebook/useNotebooksStates';
@@ -264,12 +265,23 @@ export const ConnectionsFormSection: React.FC<Props> = ({
               refreshProjectConnections();
             }
           }}
-          onSubmit={(connection: Connection) => {
+          onSubmit={async (connection: Connection) => {
             if (manageConnectionModal.isEdit) {
-              return replaceSecret(connection);
+              const response = await replaceSecret(connection);
+              if (isConnection(response)) {
+                setSelectedConnections(
+                  selectedConnections.map((c) =>
+                    c.metadata.name === response.metadata.name ? response : c,
+                  ),
+                );
+              }
+              return response;
             }
-            setSelectedConnections([...selectedConnections, connection]);
-            return createSecret(connection);
+            const response = await createSecret(connection);
+            if (isConnection(response)) {
+              setSelectedConnections([...selectedConnections, response]);
+            }
+            return response;
           }}
           isEdit={manageConnectionModal.isEdit}
         />

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -73,8 +73,6 @@ spec:
                       type: boolean
                     disableServingRuntimeParams:
                       type: boolean
-                    disableConnectionTypes:
-                      type: boolean
                     disableStorageClasses:
                       type: boolean
                     disableNIMModelServing:

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -29,7 +29,6 @@ spec:
     disableDistributedWorkloads: false
     disableModelRegistry: false
     disableServingRuntimeParams: false
-    disableConnectionTypes: true
     disableStorageClasses: false
     disableNIMModelServing: true
   groupsConfig:


### PR DESCRIPTION
Bring over last two changes related to connection types:
- [enable connection types by default](https://github.com/opendatahub-io/odh-dashboard/pull/3452)
- [Fix workbench new connection env warning / editing new connection / and save failure handling](https://github.com/opendatahub-io/odh-dashboard/pull/3462)