### PR TITLE
Fix (2.16.2): consistency of NIM status between explore and enabled pages  + Enable button improvement

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -8,4 +8,4 @@ ODH_FAVICON=odh-favicon.svg
 ODH_NOTEBOOK_REPO=opendatahub
 
 ########## Change this version with each dashboard release ###########
-INTERNAL_DASHBOARD_VERSION=v2.29.0
+INTERNAL_DASHBOARD_VERSION=v2.16.2

--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -22,15 +22,13 @@ type EnableModalProps = {
   onClose: () => void;
 };
 
-// Helper function to poll /api/integrations/nim
+// Poll /api/integrations/nim to confirm backend enablement
 const fetchNimIntegrationStatus = async (): Promise<boolean> => {
   try {
     const res = await fetch('/api/integrations/nim');
     const data = await res.json();
-    console.log('[NIM] Polled backend status from /api/integrations/nim:', data);
     return data?.isEnabled === true;
-  } catch (err) {
-    console.error('[NIM] Error fetching backend integration status:', err);
+  } catch {
     return false;
   }
 };
@@ -61,24 +59,15 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
   };
 
   const onDoEnableApp = () => {
-    console.log(`[NIM] [EnableModal] Submitting enable request for: ${selectedApp.metadata.name}`);
-    console.log('[NIM] [EnableModal] Submitted values:', enableValues);
     setPostError('');
     setValidationInProgress(true);
   };
 
   React.useEffect(() => {
-    console.log('[NIM] [EnableModal] Component re-rendered. Shown:', shown);
-  });
-
-  React.useEffect(() => {
     if (validationInProgress && validationStatus === EnableApplicationStatus.SUCCESS) {
-      console.log(`[NIM] [EnableModal] Enable request succeeded. Polling backend for confirmation...`);
-
       const interval = setInterval(async () => {
         const isEnabled = await fetchNimIntegrationStatus();
         if (isEnabled) {
-          console.log(`[NIM] ✅ NIM backend confirms isEnabled = true. Closing modal.`);
           clearInterval(interval);
           clearTimeout(timeout);
           setValidationInProgress(false);
@@ -87,21 +76,18 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
       }, 1000);
 
       const timeout = setTimeout(() => {
-        console.error(`[NIM] ❌ Timeout: backend did not confirm enablement in time.`);
         clearInterval(interval);
         setPostError('Timeout while waiting for application to be enabled.');
         setValidationInProgress(false);
       }, 50000);
 
       return () => {
-        console.log('[NIM] Cleaning up polling interval and timeout.');
         clearInterval(interval);
         clearTimeout(timeout);
       };
     }
 
     if (validationInProgress && validationStatus === EnableApplicationStatus.FAILED) {
-      console.error(`[NIM] ❌ Validation failed: ${validationErrorMessage}`);
       setValidationInProgress(false);
       setPostError(validationErrorMessage);
     }
@@ -129,7 +115,6 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, shown, onClose }
   };
 
   if (!selectedApp.spec.enable || !shown) {
-    console.log('[NIM] [EnableModal] Not shown or missing enable spec.');
     return null;
   }
 

--- a/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
+++ b/frontend/src/pages/exploreApplication/GetStartedPanel.tsx
@@ -14,9 +14,9 @@ import {
   Text,
   TextContent,
   Tooltip,
+  AlertVariant,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { AlertVariant } from '@patternfly/react-core';
 import { OdhApplication } from '~/types';
 import MarkdownView from '~/components/MarkdownView';
 import { markdownConverter } from '~/utilities/markdown';
@@ -43,7 +43,6 @@ const fetchNimIntegrationStatus = async (): Promise<boolean> => {
     const data = await res.json();
     return data?.isEnabled === true;
   } catch (err) {
-    console.error('[NIM] Failed to fetch /api/integrations/nim:', err);
     return false;
   }
 };
@@ -58,9 +57,9 @@ const GetStartedPanel: React.FC<GetStartedPanelProps> = ({ selectedApp, onClose,
   const hasNotifiedRef = React.useRef(false);
 
   React.useEffect(() => {
-    if (selectedApp?.metadata.name !== 'nvidia-nim' || isActuallyEnabled) return;
-
-    let interval: NodeJS.Timer;
+    if (selectedApp?.metadata.name !== 'nvidia-nim' || isActuallyEnabled) {
+      return;
+    }
 
     const checkEnabled = async () => {
       const enabled = await fetchNimIntegrationStatus();
@@ -82,7 +81,8 @@ const GetStartedPanel: React.FC<GetStartedPanelProps> = ({ selectedApp, onClose,
     };
 
     checkEnabled();
-    interval = setInterval(checkEnabled, 2000);
+
+    const interval = setInterval(checkEnabled, 2000);
 
     return () => clearInterval(interval);
   }, [selectedApp?.metadata.name, isActuallyEnabled, dispatch, selectedApp?.spec.displayName]);
@@ -110,7 +110,9 @@ const GetStartedPanel: React.FC<GetStartedPanelProps> = ({ selectedApp, onClose,
       </Button>
     );
 
-    return enablement ? button : (
+    return enablement ? (
+      button
+    ) : (
       <Tooltip content="This feature has been disabled by an administrator.">
         <span>{button}</span>
       </Tooltip>

--- a/frontend/src/utilities/useEnableApplication.tsx
+++ b/frontend/src/utilities/useEnableApplication.tsx
@@ -45,7 +45,7 @@ export const useEnableApplication = (
         dispatch(forceComponentsUpdate());
         return;
       }
-  
+
       dispatch(
         addNotification({
           status: AlertVariant.danger,
@@ -57,7 +57,6 @@ export const useEnableApplication = (
     },
     [appId, appName, dispatch],
   );
-  
 
   React.useEffect(() => {
     if (!doEnable) {

--- a/frontend/src/utilities/useEnableApplication.tsx
+++ b/frontend/src/utilities/useEnableApplication.tsx
@@ -32,16 +32,20 @@ export const useEnableApplication = (
   const dispatchResults = React.useCallback(
     (error?: string) => {
       if (!error) {
-        dispatch(
-          addNotification({
-            status: AlertVariant.success,
-            title: `${appName} has been added to the Enabled page.`,
-            timestamp: new Date(),
-          }),
-        );
+        // Skip notification for NVIDIA NIM; inline message will handle it
+        if (appId !== 'nvidia-nim') {
+          dispatch(
+            addNotification({
+              status: AlertVariant.success,
+              title: `${appName} has been added to the Enabled page.`,
+              timestamp: new Date(),
+            }),
+          );
+        }
         dispatch(forceComponentsUpdate());
         return;
       }
+  
       dispatch(
         addNotification({
           status: AlertVariant.danger,
@@ -51,8 +55,9 @@ export const useEnableApplication = (
         }),
       );
     },
-    [appName, dispatch],
+    [appId, appName, dispatch],
   );
+  
 
   React.useEffect(() => {
     if (!doEnable) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Related to the following:
https://issues.redhat.com/browse/NVPE-229
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
In OpenShift AI 2.16, when enabling NVIDIA NIM from the Explore page, the app appeared to be enabled immediately without actually waiting for the real backend response. Not only that, but in the Enabled page it didn't show up or was shown as disabled. After my fix, NIM now appears on the Enabled page only after it is truly enabled, and users no longer get false-positive UI states. In addition, the "Enble" button disappears after enabling.  
This created an inconsistent and confusing user experience.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Go to the Explore page and choose NIM.
2. Click the Enable button.
3. You should get success message and the button should disappear if key is valid.
4. Go to Enabled page and make sure NIM is there as enabled.

https://github.com/user-attachments/assets/efff5e1d-4d97-4123-b7bb-5f0b3fba6b02


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
