### PR TITLE
Cypress e2e fixes (#4278)

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/permissions.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/permissions.ts
@@ -84,10 +84,10 @@ class PermissionTable extends Contextual<HTMLElement> {
 
   addGroupName(name: string) {
     const userNameCell = permissions.getGroupTable().find().find('[data-label="Username"]');
-    userNameCell.findByRole('button', { name: 'Typeahead menu toggle' }).should('exist').click();
-    userNameCell.children().first().type(`${name}`);
-    //have to do this at top level `cy` because it goes to top of dom
-    cy.findByRole('option', { name: `Select "${name}"` }).click();
+    userNameCell.find('input[role="combobox"]').type(name);
+    cy.findByRole('listbox')
+      .findByRole('option', { name: `Select "${name}"` })
+      .click();
   }
 
   selectAdminOption() {
@@ -96,7 +96,7 @@ class PermissionTable extends Contextual<HTMLElement> {
       .find()
       .find('[data-label="Permission"]')
       .children()
-      .first()
+      .last()
       .findSelectOption('Admin Edit the project and manage user access')
       .click();
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dashboardNavigation/testManifestLinks.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dashboardNavigation/testManifestLinks.cy.ts
@@ -90,19 +90,12 @@ describe('Verify that all the URLs referenced in the Manifest directory are oper
           // Filter out Sample/Test URLs in a single pass
           const filteredUrls = urls.filter((url) => url && !isUrlExcluded(url, excludedSubstrings));
 
-          cy.log(`Found ${urls.length} total URLs, filtered to ${filteredUrls.length} URLs`);
-
-          // Log filtered URLs for debugging
-          filteredUrls.forEach((url) => {
-            cy.log(`[PRE-CHECK UI LOG] URL to check: ${url}`);
-          });
-
-          cy.task(
-            'log',
-            `[Step] Verifying URLs against valid status codes: ${Array.from(
-              VALID_STATUS_CODES,
-            ).join(', ')}`,
-            { log: false },
+          cy.log(
+            `Found ${urls.length} total URLs, filtered to ${
+              filteredUrls.length
+            } URLs.\nValid status codes to check: ${Array.from(VALID_STATUS_CODES).join(
+              ', ',
+            )}\n\nURLs to verify:\n${filteredUrls.join('\n')}`,
           );
 
           return cy.task<UrlValidationResult[]>('validateHttpsUrls', filteredUrls);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/createRunDeletePipelineCustomPipMirror.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/createRunDeletePipelineCustomPipMirror.cy.ts
@@ -16,10 +16,7 @@ import {
 import { provisionProjectForPipelines } from '~/__tests__/cypress/cypress/utils/pipelines';
 import { getIrisPipelinePath } from '~/__tests__/cypress/cypress/utils/fileImportUtils';
 import { createOpenShiftConfigMap } from '~/__tests__/cypress/cypress/utils/oc_commands/configmap';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 const uuid = generateTestUUID();
@@ -46,11 +43,8 @@ describe(
     });
 
     after(() => {
-      //Check if the Before Method was executed to perform the setup
-      if (!wasSetupPerformed()) return;
-
       // Delete provisioned Project
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     });
 
     it(

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
@@ -8,10 +8,7 @@ import {
   pipelineRunDetails,
 } from '~/__tests__/cypress/cypress/pages/pipelines/topology';
 import { provisionProjectForPipelines } from '~/__tests__/cypress/cypress/utils/pipelines';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 const uuid = generateTestUUID();
@@ -31,11 +28,8 @@ describe(
     });
 
     after(() => {
-      //Check if the Before Method was executed to perform the setup
-      if (!wasSetupPerformed()) return;
-
       // Delete provisioned Project
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     });
 
     it(

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageCreation.cy.ts
@@ -12,10 +12,7 @@ import {
   updateClusterStorageModal,
 } from '~/__tests__/cypress/cypress/pages/clusterStorage';
 import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/DeleteModal';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 describe('Verify Cluster Storage - Creating, Editing and Deleting', () => {
@@ -64,13 +61,10 @@ describe('Verify Cluster Storage - Creating, Editing and Deleting', () => {
       });
   });
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Delete provisioned Project
     if (projectName) {
       cy.log(`Deleting Project ${projectName} after the test has finished.`);
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     }
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/connections/testConnectionCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/connections/testConnectionCreation.cy.ts
@@ -7,10 +7,7 @@ import { loadDSPFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
 import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/DeleteModal';
 import { AWS_BUCKETS } from '~/__tests__/cypress/cypress/utils/s3Buckets';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 describe('Verify Connections - Creation and Deletion', () => {
@@ -52,13 +49,10 @@ describe('Verify Connections - Creation and Deletion', () => {
       });
   });
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Delete provisioned Project
     if (projectName) {
       cy.log(`Deleting Project ${projectName} after the test has finished.`);
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     }
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
@@ -1,10 +1,7 @@
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
 import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
 import { addConnectionModal, connectionsPage } from '~/__tests__/cypress/cypress/pages/connections';
 import {
@@ -50,11 +47,8 @@ describe(
     });
 
     after(() => {
-      //Check if the Before Method was executed to perform the setup
-      if (!wasSetupPerformed()) return;
-
-      // Delete provisioned Project - 5 min timeout to accomadate increased time to delete a project with a model
-      deleteOpenShiftProject(projectName, { timeout: 300000 });
+      // Delete provisioned Project
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     });
 
     it(

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
@@ -14,10 +14,7 @@ import {
   provisionProjectForModelServing,
   modelExternalTester,
 } from '~/__tests__/cypress/cypress/utils/oc_commands/modelServing';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { attemptToClickTooltip } from '~/__tests__/cypress/cypress/utils/models';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
@@ -58,11 +55,7 @@ describe('Verify Admin Multi Model Creation and Validation using the UI', () => 
     );
   });
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
-    // Delete provisioned Project - 5 min timeout to accomadate increased time to delete a project with a model
-    deleteOpenShiftProject(projectName, { timeout: 300000 });
+    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
   });
 
   it(
@@ -139,6 +132,10 @@ describe('Verify Admin Multi Model Creation and Validation using the UI', () => 
         checkReady: true,
         checkLatestDeploymentReady: false,
       });
+      // Usually it takes a little longer to load the status tooltip, so it's faster to Reload the page
+      cy.reload();
+      modelMeshRow.findDeployedModelExpansionButton().click();
+      // Click the status tooltip
       attemptToClickTooltip();
 
       //Verify the Model is accessible externally

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -13,10 +13,7 @@ import {
   provisionProjectForModelServing,
   modelExternalTester,
 } from '~/__tests__/cypress/cypress/utils/oc_commands/modelServing';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { attemptToClickTooltip } from '~/__tests__/cypress/cypress/utils/models';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
@@ -57,11 +54,8 @@ describe('Verify Admin Single Model Creation and Validation using the UI', () =>
     );
   });
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
-    // Delete provisioned Project - 5 min timeout to accomadate increased time to delete a project with a model
-    deleteOpenShiftProject(projectName, { timeout: 300000 });
+    // Delete provisioned Project
+    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
   });
 
   it(

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
@@ -15,10 +15,7 @@ import {
   checkInferenceServiceState,
   provisionProjectForModelServing,
 } from '~/__tests__/cypress/cypress/utils/oc_commands/modelServing';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { attemptToClickTooltip } from '~/__tests__/cypress/cypress/utils/models';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
@@ -62,11 +59,8 @@ describe('Verify Model Creation and Validation using the UI', () => {
     );
   });
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
-    // Delete provisioned Project - 5 min timeout to accomadate increased time to delete a project with a model
-    deleteOpenShiftProject(projectName, { timeout: 300000 });
+    // Delete provisioned Project
+    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
   });
 
   it(

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectAdminPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectAdminPermissions.cy.ts
@@ -9,10 +9,7 @@ import {
 import { loadDSPFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 describe('Verify that users can provide admin project permissions to non-admin users/groups', () => {
@@ -37,13 +34,10 @@ describe('Verify that users can provide admin project permissions to non-admin u
       });
   });
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Delete provisioned Project
     if (projectName) {
       cy.log(`Deleting Project ${projectName} after the test has finished.`);
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     }
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectContributorPermissions.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectContributorPermissions.cy.ts
@@ -8,10 +8,7 @@ import {
 } from '~/__tests__/cypress/cypress/utils/e2eUsers';
 import { loadDSPFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 describe('Verify that users can provide contributor project permissions to non-admin users', () => {
@@ -36,13 +33,10 @@ describe('Verify that users can provide contributor project permissions to non-a
       });
   });
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Delete provisioned Project
     if (projectName) {
       cy.log(`Deleting Project ${projectName} after the test has finished.`);
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     }
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectCreation.cy.ts
@@ -45,6 +45,14 @@ describe('Verify Data Science Project - Creation and Deletion', () => {
       });
   });
 
+  after(() => {
+    // Delete provisioned Project
+    if (projectName) {
+      cy.log(`Deleting Project ${projectName} after the test has finished.`);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+    }
+  });
+
   it(
     'Create and Delete a Data Science Project in RHOAI',
     { tags: ['@Smoke', '@SmokeSet2', '@ODS-1875', '@ODS-1783', '@ODS-1775', '@Dashboard'] },

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectEditing.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/testProjectEditing.cy.ts
@@ -8,10 +8,7 @@ import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e
 import { loadDSPFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 describe('Verify Data Science Project - Editing', () => {
@@ -36,13 +33,10 @@ describe('Verify Data Science Project - Editing', () => {
       });
   });
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Delete provisioned Project
     if (projectName) {
       cy.log(`Deleting Project ${projectName} after the test has finished.`);
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     }
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
@@ -11,10 +11,7 @@ import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e
 import { loadWBControlSuiteFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
@@ -42,13 +39,10 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
       });
   });
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Delete provisioned Project
     if (controlSuiteTestNamespace) {
       cy.log(`Deleting Project ${controlSuiteTestNamespace} after the test has finished.`);
-      deleteOpenShiftProject(controlSuiteTestNamespace);
+      deleteOpenShiftProject(controlSuiteTestNamespace, { wait: false, ignoreNotFound: true });
     }
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchCreation.cy.ts
@@ -16,10 +16,7 @@ import {
   deleteOpenShiftProject,
   addUserToProject,
 } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { addConnectionModal, connectionsPage } from '~/__tests__/cypress/cypress/pages/connections';
 import { deleteModal } from '~/__tests__/cypress/cypress/pages/components/DeleteModal';
 import { AWS_BUCKETS } from '~/__tests__/cypress/cypress/utils/s3Buckets';
@@ -74,13 +71,10 @@ describe('Create, Delete and Edit - Workbench Tests', () => {
       });
   });
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Delete provisioned Project
     if (editTestNamespace) {
       cy.log(`Deleting Project ${editTestNamespace} after the test has finished.`);
-      deleteOpenShiftProject(editTestNamespace);
+      deleteOpenShiftProject(editTestNamespace, { wait: false, ignoreNotFound: true });
     }
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchImages.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchImages.cy.ts
@@ -8,10 +8,7 @@ import {
   getNotebookImageNames,
   type NotebookImageInfo,
 } from '~/__tests__/cypress/cypress/utils/notebookImageUtils';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 
@@ -35,13 +32,10 @@ describe('Workbenches - image/version tests', () => {
   });
 
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Delete provisioned Project
     if (projectName) {
       cy.log(`Deleting Project ${projectName} after the test has finished.`);
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     }
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchNegativeTests.cy.ts
@@ -9,10 +9,7 @@ import {
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
-import {
-  retryableBeforeEach,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBeforeEach } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 describe('Workbenches - negative tests', () => {
@@ -40,13 +37,10 @@ describe('Workbenches - negative tests', () => {
   });
 
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Delete provisioned Project
     if (projectName) {
       cy.log(`Deleting Project ${projectName} after the test has finished.`);
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     }
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStatus.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStatus.cy.ts
@@ -9,10 +9,7 @@ import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e
 import { loadWBStatusFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 describe('Workbenches - status tests', () => {
@@ -39,13 +36,10 @@ describe('Workbenches - status tests', () => {
   });
 
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Delete provisioned Project
     if (projectName) {
       cy.log(`Deleting Project ${projectName} after the test has finished.`);
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     }
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
@@ -6,10 +6,7 @@ import { loadWBVariablesFixture } from '~/__tests__/cypress/cypress/utils/dataLo
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 import { validateWorkbenchEnvironmentVariables } from '~/__tests__/cypress/cypress/utils/oc_commands/workbench';
-import {
-  retryableBeforeEach,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBeforeEach } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 describe('Workbenches - variable tests', () => {
@@ -37,13 +34,10 @@ describe('Workbenches - variable tests', () => {
       });
   });
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Delete provisioned Project
     if (projectName) {
       cy.log(`Deleting Project ${projectName} after the test has finished.`);
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     }
   });
   it(

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
@@ -12,10 +12,7 @@ import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChe
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 import { createPersistentVolumeClaim } from '~/__tests__/cypress/cypress/utils/oc_commands/presistentVolumeClaim';
 import { getOpenshiftDefaultStorageClass } from '~/__tests__/cypress/cypress/utils/oc_commands/storageClass';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
 
 describe('Workbench and PVSs tests', () => {
@@ -65,13 +62,9 @@ describe('Workbench and PVSs tests', () => {
   });
 
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
-    // Delete provisioned Project
     if (projectName) {
       cy.log(`Deleting Project ${projectName} after the test has finished.`);
-      deleteOpenShiftProject(projectName);
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
     }
   });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/distributedWorkloadMetrics/testWorkloadMetricsDefaultPageContents.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/distributedWorkloadMetrics/testWorkloadMetricsDefaultPageContents.cy.ts
@@ -55,7 +55,7 @@ describe('Verify Workload Metrics Default page Contents', () => {
       projectName,
     );
     cy.log('Deleting Namespace ${projectName}');
-    deleteOpenShiftProject(projectName);
+    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
   });
 
   it(

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testCreateModelRegistry.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testCreateModelRegistry.cy.ts
@@ -1,0 +1,65 @@
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
+import {
+  FormFieldSelector,
+  modelRegistrySettings,
+} from '~/__tests__/cypress/cypress/pages/modelRegistrySettings';
+import { retryableBeforeEach } from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { checkModelRegistry } from '~/__tests__/cypress/cypress/utils/oc_commands/modelRegistry';
+
+describe('Verify a model registry can be created and deleted', () => {
+  const registryName = `e2e-test-registry`;
+
+  retryableBeforeEach(() => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+  });
+
+  it(
+    'Creates a model registry and then deletes it',
+    { tags: ['@Dashboard', '@Maintain', '@ModelRegistry', '@NonConcurrent'] },
+    () => {
+      cy.step('Login as an Admin');
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      cy.step('Navigate to Model Registry Settings');
+      modelRegistrySettings.visit();
+
+      cy.step('Create a model registry');
+      modelRegistrySettings.findCreateButton().click();
+      modelRegistrySettings.findFormField(FormFieldSelector.NAME).type(registryName);
+      modelRegistrySettings.findFormField(FormFieldSelector.HOST).type('model-registry-db');
+      modelRegistrySettings.findFormField(FormFieldSelector.PORT).type('3306');
+      modelRegistrySettings.findFormField(FormFieldSelector.USERNAME).type('mlmduser');
+      modelRegistrySettings.findFormField(FormFieldSelector.PASSWORD).type('TheBlurstOfTimes');
+      modelRegistrySettings.findFormField(FormFieldSelector.DATABASE).type('model_registry');
+      modelRegistrySettings.findSubmitButton().click();
+
+      cy.step('Verify it is available in the UI');
+      modelRegistrySettings.findModelRegistryRow(registryName).should('exist');
+      modelRegistrySettings
+        .findModelRegistryRow(registryName)
+        .contains('Available', { timeout: 120000 })
+        .should('be.visible');
+
+      cy.step('Verify model registry is created on the backend');
+      checkModelRegistry(registryName).should('be.true');
+
+      cy.step('Delete the model registry');
+      modelRegistrySettings.findModelRegistryRow(registryName).findKebab().click();
+      cy.findByRole('menuitem', { name: 'Delete model registry' }).click();
+      modelRegistrySettings.findConfirmDeleteNameInput().type(registryName);
+      cy.findByTestId('modal-submit-button').click();
+
+      cy.step('Verify model registry is removed from UI');
+      cy.contains(registryName).should('not.exist');
+
+      cy.step('Verify model registry is removed from the backend');
+      checkModelRegistry(registryName).should('be.false');
+    },
+  );
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+  });
+});

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
@@ -16,10 +16,7 @@ import {
   provisionProjectForModelServing,
   validateInferenceServiceTolerations,
 } from '~/__tests__/cypress/cypress/utils/oc_commands/modelServing';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import { attemptToClickTooltip } from '~/__tests__/cypress/cypress/utils/models';
 import {
   cleanupHardwareProfiles,
@@ -84,9 +81,6 @@ describe('Notebooks - tolerations tests', () => {
 
   //Cleanup: Delete Hardware Profile and the associated Project
   after(() => {
-    // Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Load Hardware Profile
     cy.log(`Loaded Hardware Profile Name: ${hardwareProfileResourceName}`);
 
@@ -95,7 +89,7 @@ describe('Notebooks - tolerations tests', () => {
       // Delete provisioned Project
       if (projectName) {
         cy.log(`Deleting Project ${projectName} after the test has finished.`);
-        deleteOpenShiftProject(projectName, { timeout: 300000 });
+        deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
       }
     });
   });

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
@@ -10,10 +10,7 @@ import { loadWBTolerationsFixture } from '~/__tests__/cypress/cypress/utils/data
 import { createCleanProject } from '~/__tests__/cypress/cypress/utils/projectChecker';
 import { deleteOpenShiftProject } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
 import { validateWorkbenchTolerations } from '~/__tests__/cypress/cypress/utils/oc_commands/workbench';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 import {
   cleanupHardwareProfiles,
   createCleanHardwareProfile,
@@ -56,9 +53,6 @@ describe('Workbenches - tolerations tests', () => {
 
   // Cleanup: Delete Hardware Profile and the associated Project
   after(() => {
-    // Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     // Load Hardware Profile
     cy.log(`Loaded Hardware Profile Name: ${hardwareProfileResourceName}`);
 
@@ -67,7 +61,7 @@ describe('Workbenches - tolerations tests', () => {
       // Delete provisioned Project
       if (projectName) {
         cy.log(`Deleting Project ${projectName} after the test has finished.`);
-        deleteOpenShiftProject(projectName);
+        deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
       }
     });
   });

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
@@ -7,10 +7,7 @@ import { addClusterStorageModal } from '~/__tests__/cypress/cypress/pages/cluste
 import { projectDetails, projectListPage } from '~/__tests__/cypress/cypress/pages/projects';
 import { findAddClusterStorageButton } from '~/__tests__/cypress/cypress/utils/clusterStorage';
 import { disableNonDefaultStorageClasses } from '~/__tests__/cypress/cypress/utils/oc_commands/storageClass';
-import {
-  retryableBefore,
-  wasSetupPerformed,
-} from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import { retryableBefore } from '~/__tests__/cypress/cypress/utils/retryableHooks';
 
 const dspName = 'qe-cluster-storage-sc-dsp';
 
@@ -20,9 +17,6 @@ describe('Regular Users can make use of the Storage Classes in the Cluster Stora
   });
 
   after(() => {
-    //Check if the Before Method was executed to perform the setup
-    if (!wasSetupPerformed()) return;
-
     tearDownClusterStorageSCFeature(dspName);
   });
 

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/modelRegistry.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/modelRegistry.ts
@@ -1,0 +1,19 @@
+/**
+ * Utility functions for Model Registry OC commands
+ */
+
+/**
+ * Check if a model registry exists in any namespace
+ * @param registryName Name of the model registry to check
+ * @returns Cypress.Chainable<boolean> that resolves to true if the registry exists
+ */
+export const checkModelRegistry = (registryName: string): Cypress.Chainable<boolean> => {
+  const command = `oc get modelregistry.modelregistry.opendatahub.io --all-namespaces | grep ${registryName}`;
+  cy.log(`Running command: ${command}`);
+  return cy.exec(command, { failOnNonZeroExit: false }).then((result: Cypress.Exec) => {
+    if (result.stdout) {
+      cy.log(`Command output: ${result.stdout}`);
+    }
+    return cy.wrap(result.code === 0);
+  });
+};

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
@@ -31,25 +31,36 @@ export const createOpenShiftProject = (
  * Delete an OpenShift Project given its name
  *
  * @param projectName OpenShift Project name
+ * @param options Configuration options for the delete operation
+ * @param options.timeout Timeout in milliseconds for the command (only used when wait is true)
+ * @param options.wait Whether to wait for the deletion to complete (default: true)
+ * @param options.ignoreNotFound Whether to ignore if the project doesn't exist (default: false)
  * @returns Result Object of the operation
  */
 export const deleteOpenShiftProject = (
   projectName: string,
-  options: { timeout?: number } = {},
+  options: { timeout?: number; wait?: boolean; ignoreNotFound?: boolean } = {},
 ): Cypress.Chainable<CommandLineResult> => {
-  const { timeout } = options;
-  const ocCommand = `oc delete project ${projectName}`;
-  return cy
-    .exec(ocCommand, { failOnNonZeroExit: false, ...(timeout && { timeout }) })
-    .then((result) => {
-      if (result.code !== 0) {
-        cy.log(`ERROR deleting ${projectName} Project
+  const { timeout, wait = true, ignoreNotFound = false } = options;
+  const waitFlag = wait ? '' : '--wait=false';
+  const ignoreNotFoundFlag = ignoreNotFound ? '--ignore-not-found' : '';
+  const ocCommand = `oc delete project ${projectName} ${waitFlag} ${ignoreNotFoundFlag}`.trim();
+
+  // Only apply timeout if we're waiting for the deletion
+  const execOptions = {
+    failOnNonZeroExit: false,
+    ...(wait && timeout && { timeout }),
+  };
+
+  return cy.exec(ocCommand, execOptions).then((result) => {
+    if (result.code !== 0) {
+      cy.log(`ERROR deleting ${projectName} Project
                 stdout: ${result.stdout}
                 stderr: ${result.stderr}`);
-        throw new Error(`Command failed with code ${result.code}`);
-      }
-      return result;
-    });
+      throw new Error(`Command failed with code ${result.code}`);
+    }
+    return result;
+  });
 };
 
 /**

--- a/frontend/src/__tests__/cypress/cypress/utils/projectChecker.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/projectChecker.ts
@@ -20,7 +20,7 @@ export const createCleanProject = (projectName: string): void => {
   verifyOpenShiftProjectExists(projectName).then((exists) => {
     if (exists) {
       cy.log(`Project ${projectName} already exists. Deleting it.`);
-      deleteOpenShiftProject(projectName, { timeout: 300000 });
+      deleteOpenShiftProject(projectName, { wait: true });
     }
     cy.log(`Creating project ${projectName}`);
     createAndVerifyProject(projectName);

--- a/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
@@ -83,7 +83,7 @@ export const provisionClusterStorageSCFeature = (projectName: string, userName: 
  */
 export const tearDownClusterStorageSCFeature = (projectName: string): void => {
   // Delete provisioned projectName
-  deleteOpenShiftProject(projectName);
+  deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
 };
 
 /**

--- a/frontend/src/__tests__/cypress/cypress/utils/urlExtractor.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/urlExtractor.ts
@@ -38,7 +38,7 @@ type YamlArray = YamlValue[];
  */
 function extractUrlsFromValue(value: YamlValue, urlSet: Set<string>): void {
   if (typeof value === 'string') {
-    const urlRegex = /https?:\/\/[^\s\](),"'}*]*(?=[\s\](),"'}*]|$)/g; // Matches both HTTP and HTTPS
+    const urlRegex = /^(?:https?:\/\/)[^\s\](),"'}*]*(?=[\s\](),"'}*]|$)/g; // Matches only http:// or https:// exactly
     const matches = value.match(urlRegex);
     if (matches) {
       matches.forEach((url) => {

--- a/frontend/src/__tests__/cypress/cypress/utils/urlValidator.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/urlValidator.ts
@@ -24,10 +24,10 @@ const commonUserAgent =
 const maxRedirects = 5;
 
 /** Request timeout in milliseconds */
-const requestTimeout = 30000;
+const requestTimeout = 50000;
 
 /** Maximum number of retries for network errors */
-const maxRetries = 3;
+const maxRetries = 5;
 
 /** Initial retry delay in milliseconds */
 const initialRetryDelay = 1000;


### PR DESCRIPTION
* test : Fix multiModelAdminCreation (#4241)

* Reload the page when the status is Succeeded

* Add debug logs

* lint fix

* Delete frontend/src/__tests__/cypress/config.json

* fix: testProjectAdminPermissions test (#4250)

* fix: testProjectAdminPermissions test

* lint fixes

* Fix Cypress URL regex and increase validation timeout and retries (#4246)




* test: support not waiting for oc delete (#4244)

* test: Support not waiting for oc delete

* lint fixes

* add wait=false in all the e2e tests teardown

* wait project to be deleted completely before recreating it

* Print cypress step(), exec() and log() to terminal (#4255)



* Cypress e2e Test - Verify a model registry can be created and deleted (#4257)

* adding new test

* implement existing selector page objects

---------



* Cypress parallel tests resources teardown (#4264)

* Support ignoreNotFound when doing oc delete

* modify the cleanup

* add debug log

* add wait too

* delete the mocha after() override

* lint fix

---------

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Brings https://issues.redhat.com/browse/RHOAIENG-26327 into 2.21

