### PR TITLE
Update axios dependencies to ^1.12.0 across all packages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,7 +81,7 @@
     "@patternfly/react-virtualized-extension": "^6.1.0",
     "@segment/analytics-next": "^1.72.0",
     "@types/classnames": "^2.3.1",
-    "axios": "^1.6.4",
+    "axios": "^1.12.0",
     "classnames": "^2.2.6",
     "compare-versions": "^3.6.0",
     "dompurify": "^3.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,7 @@
         "@patternfly/react-virtualized-extension": "^6.1.0",
         "@segment/analytics-next": "^1.72.0",
         "@types/classnames": "^2.3.1",
-        "axios": "^1.6.4",
+        "axios": "^1.12.0",
         "classnames": "^2.2.6",
         "compare-versions": "^3.6.0",
         "dompurify": "^3.2.4",
@@ -9454,10 +9454,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-      "license": "MIT",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -34882,7 +34881,7 @@
         "@types/node": "^20.0.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
-        "axios": "^1.6.0",
+        "axios": "^1.12.0",
         "jest-html-reporters": "^3.1.5",
         "js-yaml": "^4.1.0",
         "openapi-response-validator": "^12.1.3",

--- a/packages/contract-tests/package.json
+++ b/packages/contract-tests/package.json
@@ -17,7 +17,7 @@
     "@types/node": "^20.0.0",
     "ts-jest": "^29.0.0",
     "@types/js-yaml": "^4.0.9",
-    "axios": "^1.6.0",
+    "axios": "^1.12.0",
     "jest-html-reporters": "^3.1.5",
     "@apidevtools/json-schema-ref-parser": "^11.0.0",
     "openapi-response-validator": "^12.1.3",

--- a/packages/gen-ai/frontend/package-lock.json
+++ b/packages/gen-ai/frontend/package-lock.json
@@ -32,7 +32,7 @@
         "@types/react-dom": "^18",
         "@types/react-router-dom": "^5.3.3",
         "@typescript-eslint/eslint-plugin": "^8.17.0",
-        "axios": "^1.9.0",
+        "axios": "^1.12.0",
         "copy-webpack-plugin": "^12.0.2",
         "core-js": "^3.44.0",
         "css-loader": "^7.1.2",
@@ -7714,11 +7714,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",

--- a/packages/gen-ai/frontend/package.json
+++ b/packages/gen-ai/frontend/package.json
@@ -42,7 +42,7 @@
     "@types/react-dom": "^18",
     "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^8.17.0",
-    "axios": "^1.9.0",
+    "axios": "^1.12.0",
     "copy-webpack-plugin": "^12.0.2",
     "core-js": "^3.44.0",
     "css-loader": "^7.1.2",


### PR DESCRIPTION
Updates axios dependencies from various versions (^1.6.0, ^1.6.4, ^1.9.0) to ^1.12.0 across all packages in the monorepo. Includes updates to frontend, gen-ai frontend, contract tests packages and their corresponding lock files.