### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-dashboard-v2-20

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -52,7 +52,8 @@ WORKDIR /usr/src/app/backend
 CMD ["npm", "run", "start"]
 
 LABEL com.redhat.component="odh-dashboard-container" \
-      name="managed-open-data-hub/odh-dashboard-rhel8" \
+      name="rhoai/odh-dashboard-rhel8" \
+      cpe="cpe:/a:redhat:openshift_ai:2.20::el8" \
       description="odh-dashboard" \
       summary="odh-dashboard" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
