### PR TITLE
Trim response to just needed body

### DIFF
--- a/backend/src/routes/api/nim-serving/index.ts
+++ b/backend/src/routes/api/nim-serving/index.ts
@@ -36,12 +36,11 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
       }
 
       try {
-        // Fetch the resource from Kubernetes using the dynamically retrieved name
-        if (resourceInfo.type === 'Secret') {
-          return await coreV1Api.readNamespacedSecret(resourceName, namespace);
-        } else {
-          return await coreV1Api.readNamespacedConfigMap(resourceName, namespace);
-        }
+        const result =
+          resourceInfo.type === 'Secret'
+            ? await coreV1Api.readNamespacedSecret(resourceName, namespace)
+            : await coreV1Api.readNamespacedConfigMap(resourceName, namespace);
+        return { body: result.body };
       } catch (e: any) {
         fastify.log.error(
           `Failed to fetch ${resourceInfo.type.toLowerCase()} ${resourceName}: ${e.message}`,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-57749

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Trim the k8 api response in NIM serving route to return only the body field instead of the whole response object. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
While logged into the dashboard, navigate to  `<base-url>/api/nim-serving/apiKeySecret`. 
With no NIM `Account` CR on the cluster, the endpoint returns:
```json
{
  "statusCode": 404,
  "code": "404",
  "error": "Not Found",
  "message": "NIM account not found"
}
```
After applying a test `Account` CR and linked `Secret`:
```yaml
apiVersion: nim.opendatahub.io/v1
kind: Account
metadata:
  name: example
  namespace: redhat-ods-applications
spec:
  apiKeySecret:
    name: foo-bar
---
apiVersion: v1
kind: Secret
metadata:
  name: foo-bar
  namespace: redhat-ods-applications
type: Opaque
data:
  foo: YmFy
```
It returns only the body:
```json
{
  "body": {
    "apiVersion": "v1",
    "data": {
      "foo": "YmFy"
    },
    "kind": "Secret",
    "metadata": {
      "creationTimestamp": "2026-04-10T21:29:09.000Z",
      "managedFields": [
        {
          "apiVersion": "v1",
          "fieldsType": "FieldsV1",
          "fieldsV1": {
            "f:data": {
              ".": {

              },
              "f:foo": {

              }
            },
            "f:type": {

            }
          },
          "manager": "Mozilla",
          "operation": "Update",
          "time": "2026-04-10T21:29:09.000Z"
        }
      ],
      "name": "foo-bar",
      "namespace": "redhat-ods-applications",
      "resourceVersion": "48705873",
      "uid": "1b7774db-f5e3-4e67-b621-79cc9060dc57"
    },
    "type": "Opaque"
  }
}
```


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tests aren't affected.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->


Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
