### PR TITLE
Fix legacy HWP tolerations not injected into ISVCs (#6892)

### DIFF
--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -590,6 +590,51 @@ describe('assembleInferenceService', () => {
     expect(resultKServe.spec.predictor.nodeSelector).toBeUndefined();
   });
 
+  it('should inject tolerations for legacy hardware profiles', () => {
+    const legacyHardwareProfile = mockHardwareProfile({
+      name: 'legacy-hwp',
+      uid: undefined,
+      tolerations: [
+        {
+          key: 'nvidia.com/gpu',
+          operator: TolerationOperator.EXISTS,
+          effect: TolerationEffect.NO_SCHEDULE,
+        },
+      ],
+    });
+    // mockHardwareProfile uses a destructuring default for uid, so passing
+    // undefined doesn't clear it. We must delete it explicitly.
+    delete (legacyHardwareProfile.metadata as Record<string, unknown>).uid;
+
+    const podSpecOptions = mockModelServingPodSpecOptions({
+      selectedHardwareProfile: legacyHardwareProfile,
+      tolerations: legacyHardwareProfile.spec.scheduling?.node?.tolerations,
+      nodeSelector: { 'nvidia.com/gpu.present': 'true' },
+      resources: {
+        requests: { cpu: '1', memory: '2Gi' },
+        limits: { cpu: '2', memory: '4Gi' },
+      },
+    });
+
+    const result = assembleInferenceService(
+      mockInferenceServiceModalData({}),
+      undefined,
+      undefined,
+      false,
+      undefined,
+      undefined,
+      podSpecOptions,
+    );
+
+    expect(result.spec.predictor.tolerations).toEqual(
+      legacyHardwareProfile.spec.scheduling?.node?.tolerations,
+    );
+    expect(result.spec.predictor.nodeSelector).toEqual({ 'nvidia.com/gpu.present': 'true' });
+    expect(result.metadata.annotations?.['opendatahub.io/legacy-hardware-profile-name']).toBe(
+      'legacy-hwp',
+    );
+  });
+
   it('should set pod specs for accelerator profiles', () => {
     const gpuTolerations = [
       {

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -15,6 +15,7 @@ import { applyK8sAPIOptions } from '#~/api/apiMergeUtils';
 import { getInferenceServiceDeploymentMode } from '#~/pages/modelServing/screens/projects/utils';
 import { parseCommandLine } from '#~/api/k8s/utils';
 import { ModelServingPodSpecOptions } from '#~/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
+import { isLegacyHardwareProfileSelected } from '#~/concepts/hardwareProfiles/utils';
 import { getModelServingProjects } from './projects';
 
 const applyAuthToInferenceService = (
@@ -148,10 +149,7 @@ export const assembleInferenceService = (
 
   const dashboardNamespace = data.dashboardNamespace ?? '';
   if (!isModelMesh && podSpecOptions && podSpecOptions.selectedHardwareProfile) {
-    const isLegacyHardwareProfile =
-      !!podSpecOptions.selectedAcceleratorProfile ||
-      !podSpecOptions.selectedHardwareProfile.metadata.uid;
-    if (!isLegacyHardwareProfile) {
+    if (!isLegacyHardwareProfileSelected(podSpecOptions)) {
       annotations['opendatahub.io/hardware-profile-name'] =
         podSpecOptions.selectedHardwareProfile.metadata.name;
     } else {
@@ -230,7 +228,10 @@ export const assembleInferenceService = (
 
   if (!isModelMesh && podSpecOptions) {
     const { tolerations, resources, nodeSelector } = podSpecOptions;
-    if (!podSpecOptions.selectedHardwareProfile) {
+    if (
+      !podSpecOptions.selectedHardwareProfile ||
+      isLegacyHardwareProfileSelected(podSpecOptions)
+    ) {
       if (tolerations) {
         updatedInferenceService.spec.predictor.tolerations = tolerations;
       }

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -10,6 +10,7 @@ import {
 } from '#~/types';
 import { useIsAreaAvailable, SupportedArea } from '#~/concepts/areas';
 import { splitValueUnit, CPU_UNITS, MEMORY_UNITS_FOR_PARSING } from '#~/utilities/valueUnits';
+import { PodSpecOptions } from './types';
 
 export const formatToleration = (toleration: Toleration): string => {
   const parts = [`Key = ${toleration.key}`];
@@ -174,3 +175,8 @@ export const getProfileScore = (profile: HardwareProfileKind): number => {
 
   return score;
 };
+
+export const isLegacyHardwareProfileSelected = (podSpecOptions: PodSpecOptions): boolean =>
+  !!podSpecOptions.selectedHardwareProfile &&
+  (!!podSpecOptions.selectedAcceleratorProfile ||
+    !podSpecOptions.selectedHardwareProfile.metadata.uid);


### PR DESCRIPTION
Fix legacy HWP tolerations not injected into ISVCs on 2.25.