### PR TITLE
fix: add missing on-target-branch to pull-request pipelines

### DIFF
--- a/.tekton/odh-dashboard-pull-request.yaml
+++ b/.tekton/odh-dashboard-pull-request.yaml
@@ -9,7 +9,6 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
     pipelinesascode.tekton.dev/on-target-branch: "[rhoai-3.3]"
-    pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-dashboard-pull-request.yaml
+++ b/.tekton/odh-dashboard-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-target-branch: "[rhoai-3.3]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:

--- a/.tekton/odh-dashboard-pull-request.yaml
+++ b/.tekton/odh-dashboard-pull-request.yaml
@@ -31,6 +31,8 @@ spec:
     value:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-dashboard
+  - name: rhoai-version
+    value: "3.3.3"
   - name: output-image
     value: quay.io/rhoai/pull-request-pipelines:odh-dashboard-{{revision}}
   - name: build-platforms

--- a/.tekton/odh-dashboard-pull-request.yaml
+++ b/.tekton/odh-dashboard-pull-request.yaml
@@ -56,6 +56,8 @@ spec:
       ]
   - name: build-image-index
     value: true
+  - name: fips-check-blocking
+    value: "false"
   - name: enable-slack-failure-notification
     value: "false"
   pipelineRef:

--- a/.tekton/odh-mod-arch-gen-ai-pull-request.yaml
+++ b/.tekton/odh-mod-arch-gen-ai-pull-request.yaml
@@ -9,7 +9,6 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-comment: "^/build-konflux-gen-ai"
     pipelinesascode.tekton.dev/on-target-branch: "[rhoai-3.3]"
-    pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-mod-arch-gen-ai-pull-request.yaml
+++ b/.tekton/odh-mod-arch-gen-ai-pull-request.yaml
@@ -31,6 +31,8 @@ spec:
     value:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-mod-arch-gen-ai
+  - name: rhoai-version
+    value: "3.3.3"
   - name: output-image
     value: quay.io/rhoai/pull-request-pipelines:odh-mod-arch-gen-ai-{{revision}}
   - name: build-platforms

--- a/.tekton/odh-mod-arch-gen-ai-pull-request.yaml
+++ b/.tekton/odh-mod-arch-gen-ai-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-comment: "^/build-konflux-gen-ai"
+    pipelinesascode.tekton.dev/on-target-branch: "[rhoai-3.3]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:

--- a/.tekton/odh-mod-arch-model-registry-pull-request.yaml
+++ b/.tekton/odh-mod-arch-model-registry-pull-request.yaml
@@ -9,7 +9,6 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
     pipelinesascode.tekton.dev/on-target-branch: "[rhoai-3.3]"
-    pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-mod-arch-model-registry-pull-request.yaml
+++ b/.tekton/odh-mod-arch-model-registry-pull-request.yaml
@@ -29,6 +29,8 @@ spec:
     value:
     - version=on-pr-{{revision}}
     - io.openshift.tags=odh-mod-arch-model-registry
+  - name: rhoai-version
+    value: "3.3.3"
   - name: output-image
     value: quay.io/rhoai/pull-request-pipelines:odh-mod-arch-model-registry-{{revision}}
   - name: dockerfile

--- a/.tekton/odh-mod-arch-model-registry-pull-request.yaml
+++ b/.tekton/odh-mod-arch-model-registry-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-target-branch: "[rhoai-3.3]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:


### PR DESCRIPTION
## Summary
- Added missing `pipelinesascode.tekton.dev/on-target-branch: "[rhoai-3.3]"` annotation to all three pull-request pipelines so PaC can match PR events to this branch
- Removed `pipelinesascode.tekton.dev/on-event: "[pull_request]"` so builds only trigger via `/build-konflux` comment, not automatically on every PR event
- Added missing `rhoai-version: "3.3.3"` param to all three pull-request pipelines — the `rhoai-init` task requires it but only the push pipelines had it
- Added missing `fips-check-blocking: "false"` param to `odh-dashboard-pull-request.yaml` to match its push pipeline counterpart

### Files changed
- `.tekton/odh-dashboard-pull-request.yaml`
- `.tekton/odh-mod-arch-gen-ai-pull-request.yaml`
- `.tekton/odh-mod-arch-model-registry-pull-request.yaml`

## Root Cause
The pull-request pipelines on `rhoai-3.3` had multiple issues:
1. Missing `on-target-branch` annotation — PaC couldn't match `/build-konflux` comments on PRs targeting this branch
2. Missing `rhoai-version` param — the `rhoai-init` task failed immediately with `ERROR: RHOAI version is required but was not provided`
3. Missing `fips-check-blocking` param on the dashboard pull-request pipeline

## Test plan
- [ ] After merge, post `/build-konflux` on a PR targeting `rhoai-3.3` and verify the pipeline triggers and passes `rhoai-init`


Closes: https://redhat.atlassian.net/browse/RHOAIENG-61352