### PR TITLE
chore(deps): update ubi9/go-toolset in Dockerfile.konflux.genai from 1.24 to 1.25

### DIFF
--- a/Dockerfile.konflux.genai
+++ b/Dockerfile.konflux.genai
@@ -9,7 +9,7 @@ ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/bff
 
 # Set the base images for the build stages
 ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22@sha256:e06a0042a0a1502696a6f139f50e7fc1048a38d9c8358747c36d8905bf3f9258
-ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060
+ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e
 ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal@sha256:12db9874bd753eb98b1ab3d840e75de5d6842ac0604fbd68c012adefe97140be
 
 # UI build stage


### PR DESCRIPTION
## Description

Bumps the Go base image in `Dockerfile.konflux.genai` from `go-toolset:1.24` to `go-toolset:1.25`, matching the digest already used by `Dockerfile.konflux.mlflow`.

Fixes the following Konflux build failure:
https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5-ea-1/pipelineruns/odh-mod-arch-gen-ai-v3-5-ea-1-on-push-j4fqm/logs

## How Has This Been Tested?

This is a base image version bump with no logic change. The image is the same one already validated by mlflow builds.

## Test Impact

No tests required — no code logic changed, only the Go toolchain version used in the BFF build stage.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`