### PR TITLE
Upgrade Konflux Dockerfiles from ubi9/nodejs-20 to ubi9/nodejs-22

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,7 +1,7 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-FROM registry.access.redhat.com/ubi9/nodejs-20@sha256:74cc7b1d13592b1e425074f434b90e470ab209da85fd1fdb8e6e9e4cabaec51a as builder
+FROM registry.access.redhat.com/ubi9/nodejs-22@sha256:0fdb6844ce7a2a2e5d3d6c69b8023e7be72ddf992ade5ca26e1d1d1924121454 as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
@@ -35,7 +35,7 @@ RUN npm run build
 # This is needed to remove the dev dependencies that were installed in the previous step
 RUN npm prune --omit=dev
 
-FROM registry.access.redhat.com/ubi9/nodejs-20@sha256:74cc7b1d13592b1e425074f434b90e470ab209da85fd1fdb8e6e9e4cabaec51a as runtime
+FROM registry.access.redhat.com/ubi9/nodejs-22@sha256:0fdb6844ce7a2a2e5d3d6c69b8023e7be72ddf992ade5ca26e1d1d1924121454 as runtime
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile.konflux.modelregistry
+++ b/Dockerfile.konflux.modelregistry
@@ -8,7 +8,7 @@ ARG UI_SOURCE_CODE=./packages/${MODULE_NAME}/upstream/frontend
 ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/upstream/bff
 
 # Set the base images for the build stages
-ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-20@sha256:74cc7b1d13592b1e425074f434b90e470ab209da85fd1fdb8e6e9e4cabaec51a
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22@sha256:0fdb6844ce7a2a2e5d3d6c69b8023e7be72ddf992ade5ca26e1d1d1924121454
 ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e
 ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal@sha256:5b74fce9d6e629942a0c6dc0f546c193e70d7f974d999a48c948c53dd3d36362
 

--- a/Dockerfile.konflux.sealights
+++ b/Dockerfile.konflux.sealights
@@ -1,7 +1,7 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-FROM registry.access.redhat.com/ubi9/nodejs-20@sha256:74cc7b1d13592b1e425074f434b90e470ab209da85fd1fdb8e6e9e4cabaec51a as builder
+FROM registry.access.redhat.com/ubi9/nodejs-22@sha256:0fdb6844ce7a2a2e5d3d6c69b8023e7be72ddf992ade5ca26e1d1d1924121454 as builder
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
@@ -67,7 +67,7 @@ USER default
 # This is needed to remove the dev dependencies that were installed in the previous step
 RUN npm prune --omit=dev
 
-FROM registry.access.redhat.com/ubi9/nodejs-20@sha256:74cc7b1d13592b1e425074f434b90e470ab209da85fd1fdb8e6e9e4cabaec51a as runtime
+FROM registry.access.redhat.com/ubi9/nodejs-22@sha256:0fdb6844ce7a2a2e5d3d6c69b8023e7be72ddf992ade5ca26e1d1d1924121454 as runtime
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Summary
- `ubi9/nodejs-20` has been **deprecated** by Red Hat, causing `deprecated-base-image-check` failures in Konflux conforma builds for `odh-dashboard-v2-25` and `odh-mod-arch-model-registry-v2-25`.
- Updates all Konflux Dockerfiles to use `ubi9/nodejs-22` with pinned digest.

## Files changed (Konflux-only, no conflict with upstream sync)
- `Dockerfile.konflux` (builder + runtime stages)
- `Dockerfile.konflux.modelregistry` (NODE_BASE_IMAGE arg)
- `Dockerfile.konflux.sealights` (builder + runtime stages)

## Related
- Upstream PR: https://github.com/opendatahub-io/odh-dashboard/pull/7670
- Jira: https://redhat.atlassian.net/browse/RHOAIENG-64644

## Test plan
- [ ] Konflux builds pass for `odh-dashboard-v2-25`
- [ ] Konflux builds pass for `odh-mod-arch-model-registry-v2-25`
- [ ] `deprecated-base-image-check` no longer fails