### PR TITLE
Update go-toolset base image from 1.25 to 1.26 for model-registry

### DIFF
--- a/Dockerfile.konflux.modelregistry
+++ b/Dockerfile.konflux.modelregistry
@@ -9,7 +9,7 @@ ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/upstream/bff
 
 # Set the base images for the build stages
 ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22@sha256:6a3eed5bfd580871fde7329421ce0b2ae533e28792f6db1accbd77602e271ad7
-ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e
+ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76
 ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal@sha256:ae09ecc3d754bc1726cbda3e2599cc7839e09fe1cc547ce173cf669b645be3cc
 
 # UI build stage


### PR DESCRIPTION
## Description

Updates the Go toolset base image in `Dockerfile.konflux.modelregistry` from `go-toolset:1.25` (Go 1.25.9) to `go-toolset:1.26` (Go 1.26.3).

The upstream `kubeflow/model-registry` BFF has bumped its `go.mod` to require Go 1.26+. Without this change, the Konflux hermetic build will fail during compilation.

### Changes

- `registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2...` → `registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:d36470d5...`

New digest verified via:
```
skopeo inspect --override-arch amd64 --override-os linux docker://registry.access.redhat.com/ubi9/go-toolset:1.26
```

## How Has This Been Tested?

- Verified the new digest is valid and resolves to Go 1.26.3 via `skopeo inspect`
- The Konflux build pipeline will validate the full image build on merge

## Test Impact

No functional test changes — this only updates the build toolchain version.


Made with [Cursor](https://cursor.com)