### PR TITLE
cherry pick mlflow and prompt e2e fixes (#8127)

### DIFF
--- a/packages/cypress/cypress/pages/mlflowExperiments.ts
+++ b/packages/cypress/cypress/pages/mlflowExperiments.ts
@@ -39,7 +39,7 @@ class MlflowExperiments {
 
   findNavItem() {
     return appChrome.findNavItem({
-      name: 'Experiments (MLflow)',
+      name: 'Experiments',
       rootSection: 'Develop & train',
     });
   }
@@ -113,7 +113,10 @@ class MlflowExperiments {
   }
 
   findCreateExperimentButton() {
-    return cy.findByTestId('create-experiment-table-empty-state-button', { timeout: 30000 });
+    return cy.get(
+      '[data-testid="create-experiment-table-empty-state-button"], [data-testid="create-experiment-button"]',
+      { timeout: 30000 },
+    );
   }
 
   findExperimentInTable(name: string) {
@@ -181,7 +184,7 @@ class MlflowExperiments {
   }
 
   findCompareRunsHeading() {
-    return cy.contains('Comparing');
+    return cy.findByTestId('mlflow-breadcrumb-active');
   }
 
   findCompareRunsVisualizations() {

--- a/packages/cypress/cypress/pages/promptManagement.ts
+++ b/packages/cypress/cypress/pages/promptManagement.ts
@@ -70,7 +70,7 @@ class PromptManagement {
   }
 
   findPromptTemplateInput() {
-    return cy.get('[data-component-id="mlflow.prompts.create.content"]');
+    return cy.get('#mlflow\\.prompts\\.create\\.content');
   }
 
   findPromptCommitMessageInput() {

--- a/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
@@ -2,7 +2,6 @@ import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
 import {
   enableMlflowFeatures,
   disableMlflowFeatures,
-  isMlflowOperatorManaged,
   doesMlflowCRExist,
   createMlflowExperimentViaAPI,
   deleteMlflowExperimentViaAPI,
@@ -20,8 +19,7 @@ import type { MlflowExperimentsTestData } from '../../../types';
 describe('Verify MLflow Experiments page', () => {
   let testData: MlflowExperimentsTestData;
   let projectName: string;
-  let operatorWasManaged = true;
-  let crExisted = true;
+  let crExisted: boolean | undefined;
   let runsExperimentId: string | undefined;
   let uiExperimentName: string | undefined;
   let uiExperimentDeleted = false;
@@ -36,18 +34,13 @@ describe('Verify MLflow Experiments page', () => {
       })
       .then(() => createOpenShiftProject(projectName))
       .then(() =>
-        isMlflowOperatorManaged().then((v) => {
-          operatorWasManaged = v;
-        }),
-      )
-      .then(() =>
         doesMlflowCRExist().then((v) => {
-          crExisted = v;
-          cy.step(
-            `Pre-test state: operator=${operatorWasManaged ? 'Managed' : 'Removed'}, CR=${
-              crExisted ? 'exists' : 'absent'
-            }`,
-          );
+          if (crExisted === undefined) {
+            crExisted = v;
+            cy.log(`Pre-test state (first run): CR=${crExisted ? 'exists' : 'absent'}`);
+          } else {
+            cy.log(`Retry: skipping crExisted overwrite (current=${crExisted})`);
+          }
         }),
       )
       .then(() => {
@@ -67,7 +60,7 @@ describe('Verify MLflow Experiments page', () => {
     if (runsExperimentId) {
       deleteMlflowExperimentViaAPI(projectName, runsExperimentId);
     }
-    disableMlflowFeatures(operatorWasManaged, crExisted);
+    disableMlflowFeatures(crExisted ?? false);
     deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
   });
 

--- a/packages/cypress/cypress/tests/e2e/promptManagement/testPromptManagement.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/promptManagement/testPromptManagement.cy.ts
@@ -2,9 +2,7 @@ import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
 import {
   enablePromptManagementFeatures,
   disablePromptManagementFeatures,
-  isMlflowOperatorManaged,
   doesMlflowCRExist,
-  isGenAiEnabled,
 } from '../../../utils/oc_commands/mlflow';
 import { deleteOpenShiftProject, createOpenShiftProject } from '../../../utils/oc_commands/project';
 import { retryableBefore } from '../../../utils/retryableHooks';
@@ -17,9 +15,7 @@ import type { PromptManagementTestData } from '../../../types';
 describe('Verify Prompt Management page', () => {
   let testData: PromptManagementTestData;
   let projectName: string;
-  let operatorWasManaged = true;
-  let crExisted = true;
-  let genAiWasEnabled = true;
+  let crExisted: boolean | undefined;
   const uuid = generateTestUUID();
 
   retryableBefore(() => {
@@ -31,23 +27,13 @@ describe('Verify Prompt Management page', () => {
       })
       .then(() => createOpenShiftProject(projectName))
       .then(() =>
-        isMlflowOperatorManaged().then((v) => {
-          operatorWasManaged = v;
-        }),
-      )
-      .then(() =>
         doesMlflowCRExist().then((v) => {
-          crExisted = v;
-        }),
-      )
-      .then(() =>
-        isGenAiEnabled().then((v) => {
-          genAiWasEnabled = v;
-          cy.step(
-            `Pre-test state: operator=${operatorWasManaged ? 'Managed' : 'Removed'}, CR=${
-              crExisted ? 'exists' : 'absent'
-            }, GenAI=${genAiWasEnabled ? 'enabled' : 'disabled'}`,
-          );
+          if (crExisted === undefined) {
+            crExisted = v;
+            cy.log(`Pre-test state (first run): CR=${crExisted ? 'exists' : 'absent'}`);
+          } else {
+            cy.log(`Retry: skipping crExisted overwrite (current=${crExisted})`);
+          }
         }),
       )
       .then(() => {
@@ -57,7 +43,7 @@ describe('Verify Prompt Management page', () => {
   });
 
   after(() => {
-    disablePromptManagementFeatures(operatorWasManaged, crExisted, genAiWasEnabled);
+    disablePromptManagementFeatures(crExisted ?? false);
     deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
   });
 

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -666,7 +666,7 @@ const execCurlInMlflowPod = (
       `printf '%s' '${escapedBody}'`,
       '|',
       `oc exec -n ${namespace} -i ${podName} -c mlflow --`,
-      `curl -sk -X POST 'https://localhost:8443${endpoint}'`,
+      `curl -sk -X POST 'https://localhost:8443/mlflow${endpoint}'`,
       `-H 'Content-Type: application/json'`,
       `-H "Authorization: Bearer $(oc whoami -t)"`,
       `-H 'X-MLFLOW-WORKSPACE: ${ns}'`,

--- a/packages/mlflow-embedded/shared/MlflowBreadcrumbs.tsx
+++ b/packages/mlflow-embedded/shared/MlflowBreadcrumbs.tsx
@@ -24,6 +24,7 @@ const MlflowBreadcrumbs: React.FC<{
         <BreadcrumbItem
           key={b.path}
           isActive={isLast}
+          {...(isLast ? { 'data-testid': 'mlflow-breadcrumb-active' } : {})}
           render={() =>
             isLast ? (
               b.label


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
