### PR TITLE
Backport timeout field (#8117)

### DIFF
--- a/frontend/src/components/NumberInputWrapper.scss
+++ b/frontend/src/components/NumberInputWrapper.scss
@@ -1,4 +1,8 @@
 .odh-number-input-wrapper {
+  .pf-v6-c-number-input__unit {
+    white-space: nowrap;
+  }
+
   &.m-full-width {
     width: 100%;
     display: flex;
@@ -7,9 +11,6 @@
       .pf-v6-c-form-control {
         width: 100%;
       }
-    }
-    .pf-v6-c-number-input__unit {
-      white-space: nowrap;
     }
   }
 }

--- a/frontend/src/components/NumberInputWrapper.tsx
+++ b/frontend/src/components/NumberInputWrapper.tsx
@@ -8,6 +8,7 @@ type NumberInputWrapperProps = {
   onBlur?: (blurValue: number | undefined) => void;
   onChange?: (newValue: number | undefined) => void;
   intOnly?: boolean;
+  increment?: number;
   fullWidth?: boolean;
 } & Omit<React.ComponentProps<typeof NumberInput>, 'onChange' | 'onPlus' | 'onMinus'>;
 
@@ -15,6 +16,7 @@ const NumberInputWrapper: React.FC<NumberInputWrapperProps> = ({
   onBlur,
   onChange,
   intOnly = true,
+  increment = 1,
   fullWidth = false,
   value,
   validated,
@@ -23,7 +25,7 @@ const NumberInputWrapper: React.FC<NumberInputWrapperProps> = ({
   ...otherProps
 }) => (
   <NumberInput
-    className={fullWidth ? 'odh-number-input-wrapper m-full-width' : undefined}
+    className={fullWidth ? 'odh-number-input-wrapper m-full-width' : 'odh-number-input-wrapper'}
     inputProps={{ placeholder: '' }}
     inputName="value-unit-input"
     {...otherProps}
@@ -43,10 +45,10 @@ const NumberInputWrapper: React.FC<NumberInputWrapperProps> = ({
                 onChange(undefined);
                 return;
               }
-              if (min) {
+              if (min != null) {
                 v = Math.max(v, min);
               }
-              if (max) {
+              if (max != null) {
                 v = Math.min(v, max);
               }
               onChange(v);
@@ -64,16 +66,16 @@ const NumberInputWrapper: React.FC<NumberInputWrapperProps> = ({
     onPlus={
       onChange
         ? () => {
-            const newVal = (value || 0) + 1;
-            onChange(min ? Math.max(newVal, min) : newVal);
+            const newVal = (value || 0) + increment;
+            onChange(max != null ? Math.min(newVal, max) : newVal);
           }
         : undefined
     }
     onMinus={
       onChange
         ? () => {
-            const newVal = (value || 0) - 1;
-            onChange(max ? Math.min(newVal, max) : newVal);
+            const newVal = (value || 0) - increment;
+            onChange(min != null ? Math.max(newVal, min) : newVal);
           }
         : undefined
     }

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -501,6 +501,7 @@ export enum DeploymentMode {
 export type InferenceServiceAnnotations = DisplayNameAnnotations &
   Partial<{
     'security.opendatahub.io/enable-auth': string;
+    'security.opendatahub.io/auth-proxy-type': 'kube-rbac-proxy' | 'oauth-proxy' | string;
     'serving.kserve.io/deploymentMode': DeploymentMode;
     'serving.knative.openshift.io/enablePassthrough': 'true';
     'sidecar.istio.io/inject': 'true';
@@ -531,6 +532,7 @@ export type InferenceServiceKind = K8sResourceCommon & {
       annotations?: Record<string, string>;
       tolerations?: Toleration[];
       nodeSelector?: NodeSelector;
+      timeout?: number;
       deploymentStrategy?: {
         type: 'RollingUpdate' | 'Recreate';
       };

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -156,9 +156,8 @@ export const findTemplateByName = (
 ): TemplateKind | undefined =>
   templates.find((t) => getServingRuntimeNameFromTemplate(t) === templateName);
 
-export const isTemplateKind = (
-  resource: ServingRuntimeKind | TemplateKind,
-): resource is TemplateKind => resource.kind === 'Template';
+export const isTemplateKind = (resource: K8sResourceCommon): resource is TemplateKind =>
+  resource.kind === 'Template';
 
 export const getEnabledPlatformsFromTemplate = (
   template: TemplateKind,

--- a/frontend/src/pages/projects/screens/detail/connections/__tests__/ManageConnectionsModal.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/__tests__/ManageConnectionsModal.spec.tsx
@@ -198,7 +198,7 @@ describe('Create connection modal', () => {
                 type: 'numeric',
                 name: 'numeric 3',
                 envVar: 'env3',
-                properties: { min: 0 },
+                properties: { min: 0, max: 100 },
               },
             ],
           }),
@@ -236,18 +236,21 @@ describe('Create connection modal', () => {
     });
     expect(createButton).toBeEnabled();
 
-    // numeric
+    // numeric - values outside min/max are auto-corrected on blur
     await act(async () => {
       fireEvent.change(numeric, {
         target: { value: '-10' },
       });
+      fireEvent.blur(numeric);
     });
-    expect(createButton).toBeDisabled();
+    // Value is clamped to min (0), so button remains enabled
+    expect(createButton).toBeEnabled();
 
     await act(async () => {
       fireEvent.change(numeric, {
         target: { value: '2' },
       });
+      fireEvent.blur(numeric);
     });
     expect(createButton).toBeEnabled();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36174,6 +36174,7 @@
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/jest-config": "*",
         "@odh-dashboard/tsconfig": "*"
       }
     },

--- a/packages/jest-config/config/jest.setup.ts
+++ b/packages/jest-config/config/jest.setup.ts
@@ -9,6 +9,10 @@ import type { BooleanValues, RenderHookResultExt } from '../types';
 // @ts-ignore
 global.TextEncoder = TextEncoder;
 
+if (typeof globalThis.structuredClone === 'undefined') {
+  globalThis.structuredClone = <T>(val: T): T => JSON.parse(JSON.stringify(val));
+}
+
 // Mock webpack-injected global variables
 declare global {
   // eslint-disable-next-line no-var, @typescript-eslint/naming-convention

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -13,13 +13,17 @@ import type {
   ModelServingPlatformFetchDeploymentStatus,
   ModelServingDeploymentFormDataExtension,
   ModelServingDeploy,
+  WizardField2Extension,
+  WizardFieldApplyExtension,
+  WizardFieldExtractorExtension,
 } from '@odh-dashboard/model-serving/extension-points';
+import type { AreaExtension } from '@odh-dashboard/plugin-core/extension-points';
 // eslint-disable-next-line no-restricted-syntax
 import {
   DataScienceStackComponent,
   SupportedArea,
 } from '@odh-dashboard/internal/concepts/areas/index';
-import type { AreaExtension } from '@odh-dashboard/plugin-core/extension-points';
+import type { TimeoutFieldValue } from './src/wizardFields/timeout/TimeoutField';
 import type { KServeDeployment } from './src/deployments';
 
 export const KSERVE_ID = 'kserve';
@@ -36,6 +40,9 @@ const extensions: (
   | ModelServingStartStopAction<KServeDeployment>
   | ModelServingPlatformFetchDeploymentStatus<KServeDeployment>
   | ModelServingDeploy<KServeDeployment>
+  | WizardField2Extension<TimeoutFieldValue, KServeDeployment>
+  | WizardFieldApplyExtension<TimeoutFieldValue, KServeDeployment>
+  | WizardFieldExtractorExtension<TimeoutFieldValue, KServeDeployment>
 )[] = [
   {
     type: 'app.area',
@@ -174,6 +181,45 @@ const extensions: (
       priority: 0,
       supportsOverwrite: true,
       deploy: () => import('./src/deploy').then((m) => m.deployKServeDeployment),
+    },
+    flags: {
+      required: [SupportedArea.K_SERVE],
+    },
+  },
+  {
+    type: 'model-serving.deployment/wizard-field2',
+    properties: {
+      platform: KSERVE_ID,
+      field: () =>
+        import('./src/wizardFields/timeout/TimeoutField').then((m) => m.TimeoutFieldWizardField),
+    },
+    flags: {
+      required: [SupportedArea.K_SERVE],
+    },
+  },
+  {
+    type: 'model-serving.deployment/wizard-field-apply',
+    properties: {
+      fieldId: 'kserve/timeout',
+      platform: KSERVE_ID,
+      apply: () =>
+        import('./src/wizardFields/timeout/timeoutApplyExtract').then(
+          (m) => m.applyTimeoutFieldData,
+        ),
+    },
+    flags: {
+      required: [SupportedArea.K_SERVE],
+    },
+  },
+  {
+    type: 'model-serving.deployment/wizard-field-extractor',
+    properties: {
+      fieldId: 'kserve/timeout',
+      platform: KSERVE_ID,
+      extract: () =>
+        import('./src/wizardFields/timeout/timeoutApplyExtract').then(
+          (m) => m.extractTimeoutFieldData,
+        ),
     },
     flags: {
       required: [SupportedArea.K_SERVE],

--- a/packages/kserve/jest.config.ts
+++ b/packages/kserve/jest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@odh-dashboard/jest-config';

--- a/packages/kserve/package.json
+++ b/packages/kserve/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
-    "test:fix": "eslint --ext .js,.ts,.jsx,.tsx . --fix"
+    "test:fix": "eslint --ext .js,.ts,.jsx,.tsx . --fix",
+    "test-unit": "jest --silent",
+    "test-unit-coverage": "jest --silent --coverage"
   },
   "exports": {
     "./extensions": "./extensions.ts",
@@ -18,6 +20,7 @@
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",
+    "@odh-dashboard/jest-config": "*",
     "@odh-dashboard/tsconfig": "*"
   }
 }

--- a/packages/kserve/src/__tests__/deployments.spec.ts
+++ b/packages/kserve/src/__tests__/deployments.spec.ts
@@ -20,7 +20,7 @@ const mockUseWatchServingRuntimes = watchModule.useWatchServingRuntimes as jest.
 const mockUseWatchDeploymentPods = watchModule.useWatchDeploymentPods as jest.Mock;
 
 // Type helper for hook return value
-type DeploymentHookResult = [KServeDeployment[] | undefined, boolean, Error | undefined];
+type DeploymentHookResult = [KServeDeployment[] | undefined, boolean, Error[] | undefined];
 
 describe('useWatchDeployments', () => {
   let mockProject: ProjectKind;
@@ -76,7 +76,7 @@ describe('useWatchDeployments', () => {
 
     expect(deployments).toHaveLength(3);
     expect(loaded).toBe(true);
-    expect(error).toBeUndefined();
+    expect(error).toHaveLength(0);
   });
 
   it('should filter deployments when filterFn is provided', () => {
@@ -91,7 +91,7 @@ describe('useWatchDeployments', () => {
     expect(deployments?.[0].model.metadata.name).toBe('model-1');
     expect(deployments?.[1].model.metadata.name).toBe('model-2');
     expect(loaded).toBe(true);
-    expect(error).toBeUndefined();
+    expect(error).toHaveLength(0);
   });
 
   it('should return empty array when filterFn filters out all deployments', () => {
@@ -104,7 +104,7 @@ describe('useWatchDeployments', () => {
 
     expect(deployments).toHaveLength(0);
     expect(loaded).toBe(true);
-    expect(error).toBeUndefined();
+    expect(error).toHaveLength(0);
   });
 
   it('should match serving runtimes to inference services', () => {
@@ -155,9 +155,9 @@ describe('useWatchDeployments', () => {
 
     const renderResult = testHook(useWatchDeployments)(mockProject, undefined, undefined);
 
-    const [, , error] = renderResult.result.current as DeploymentHookResult;
+    const [, , errors] = renderResult.result.current as DeploymentHookResult;
 
-    expect(error).toBe(mockError);
+    expect(errors).toContain(mockError);
   });
 
   it('should pass through error state from serving runtimes', () => {
@@ -166,9 +166,9 @@ describe('useWatchDeployments', () => {
 
     const renderResult = testHook(useWatchDeployments)(mockProject, undefined, undefined);
 
-    const [, , error] = renderResult.result.current as DeploymentHookResult;
+    const [, , errors] = renderResult.result.current as DeploymentHookResult;
 
-    expect(error).toBe(mockError);
+    expect(errors).toContain(mockError);
   });
 
   it('should pass through error state from deployment pods', () => {
@@ -177,9 +177,9 @@ describe('useWatchDeployments', () => {
 
     const renderResult = testHook(useWatchDeployments)(mockProject, undefined, undefined);
 
-    const [, , error] = renderResult.result.current as DeploymentHookResult;
+    const [, , errors] = renderResult.result.current as DeploymentHookResult;
 
-    expect(error).toBe(mockError);
+    expect(errors).toContain(mockError);
   });
 
   it('should update deployments when filterFn changes', () => {

--- a/packages/kserve/src/__tests__/timeout.spec.ts
+++ b/packages/kserve/src/__tests__/timeout.spec.ts
@@ -1,0 +1,241 @@
+import type { InferenceServiceKind } from '@odh-dashboard/internal/k8sTypes';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/internal/__mocks__/mockInferenceServiceK8sResource';
+import {
+  applyTimeoutConfig,
+  extractTimeoutConfig,
+} from '../wizardFields/timeout/timeoutApplyExtract';
+
+describe('applyTimeoutConfig', () => {
+  let mockInferenceService: InferenceServiceKind;
+
+  beforeEach(() => {
+    mockInferenceService = mockInferenceServiceK8sResource({
+      name: 'test-model',
+      namespace: 'test-project',
+    });
+  });
+  it('should return unchanged InferenceService when timeoutConfig is undefined', () => {
+    const result = applyTimeoutConfig(mockInferenceService, undefined);
+    expect(result).toEqual(mockInferenceService);
+  });
+
+  it('should set spec.predictor.timeout when timeout is provided', () => {
+    const result = applyTimeoutConfig(mockInferenceService, {
+      timeout: 60,
+      return401: false,
+    });
+
+    expect(result.spec.predictor.timeout).toBe(60);
+  });
+
+  it('should set auth-proxy-type annotation when return401 is true', () => {
+    const result = applyTimeoutConfig(mockInferenceService, {
+      timeout: 30,
+      return401: true,
+    });
+
+    expect(result.metadata.annotations?.['security.opendatahub.io/auth-proxy-type']).toBe(
+      'kube-rbac-proxy',
+    );
+  });
+
+  it('should not set auth-proxy-type annotation when return401 is false', () => {
+    const result = applyTimeoutConfig(mockInferenceService, {
+      timeout: 30,
+      return401: false,
+    });
+
+    expect(
+      result.metadata.annotations?.['security.opendatahub.io/auth-proxy-type'],
+    ).toBeUndefined();
+  });
+
+  it('should clear existing timeout on update', () => {
+    const existingService: InferenceServiceKind = {
+      ...mockInferenceService,
+      spec: {
+        ...mockInferenceService.spec,
+        predictor: {
+          ...mockInferenceService.spec.predictor,
+          timeout: 120,
+        },
+      },
+    };
+
+    const result = applyTimeoutConfig(existingService, {
+      timeout: 45,
+      return401: false,
+    });
+
+    expect(result.spec.predictor.timeout).toBe(45);
+  });
+
+  it('should clear existing auth-proxy-type annotation on update when return401 is false', () => {
+    const existingService: InferenceServiceKind = {
+      ...mockInferenceService,
+      metadata: {
+        ...mockInferenceService.metadata,
+        annotations: {
+          ...mockInferenceService.metadata.annotations,
+          'security.opendatahub.io/auth-proxy-type': 'kube-rbac-proxy',
+        },
+      },
+    };
+
+    const result = applyTimeoutConfig(existingService, {
+      timeout: 30,
+      return401: false,
+    });
+
+    expect(
+      result.metadata.annotations?.['security.opendatahub.io/auth-proxy-type'],
+    ).toBeUndefined();
+  });
+
+  it('should handle InferenceService without existing annotations', () => {
+    const serviceWithoutAnnotations: InferenceServiceKind = {
+      ...mockInferenceService,
+      metadata: {
+        ...mockInferenceService.metadata,
+        annotations: undefined,
+      },
+    };
+
+    const result = applyTimeoutConfig(serviceWithoutAnnotations, {
+      timeout: 30,
+      return401: true,
+    });
+
+    expect(result.metadata.annotations).toBeDefined();
+    expect(result.metadata.annotations?.['security.opendatahub.io/auth-proxy-type']).toBe(
+      'kube-rbac-proxy',
+    );
+  });
+
+  it('should not mutate the original InferenceService', () => {
+    const originalTimeout = mockInferenceService.spec.predictor.timeout;
+
+    applyTimeoutConfig(mockInferenceService, {
+      timeout: 90,
+      return401: true,
+    });
+
+    expect(mockInferenceService.spec.predictor.timeout).toBe(originalTimeout);
+    expect(
+      mockInferenceService.metadata.annotations?.['security.opendatahub.io/auth-proxy-type'],
+    ).toBeUndefined();
+  });
+});
+
+describe('extractTimeoutConfig', () => {
+  it('should extract timeout from existing InferenceService', () => {
+    const deployment = {
+      model: {
+        ...mockInferenceServiceK8sResource({ name: 'test-model' }),
+        spec: {
+          predictor: {
+            timeout: 60,
+            model: {
+              modelFormat: { name: 'onnx' },
+              runtime: 'test-runtime',
+            },
+          },
+        },
+      } as InferenceServiceKind,
+    };
+
+    const result = extractTimeoutConfig(deployment);
+
+    expect(result.timeout).toBe(60);
+  });
+
+  it('should return default timeout (30) when not set', () => {
+    const deployment = {
+      model: mockInferenceServiceK8sResource({ name: 'test-model' }),
+    };
+
+    const result = extractTimeoutConfig(deployment);
+
+    expect(result.timeout).toBe(30);
+  });
+
+  it('should return return401: true when auth-proxy-type annotation is kube-rbac-proxy', () => {
+    const mockService = mockInferenceServiceK8sResource({ name: 'test-model' });
+    const deployment = {
+      model: {
+        ...mockService,
+        metadata: {
+          ...mockService.metadata,
+          annotations: {
+            ...mockService.metadata.annotations,
+            'security.opendatahub.io/auth-proxy-type': 'kube-rbac-proxy',
+          },
+        },
+      } as InferenceServiceKind,
+    };
+
+    const result = extractTimeoutConfig(deployment);
+
+    expect(result.return401).toBe(true);
+  });
+
+  it('should return return401: false when auth-proxy-type annotation is not set', () => {
+    const deployment = {
+      model: mockInferenceServiceK8sResource({ name: 'test-model' }),
+    };
+
+    const result = extractTimeoutConfig(deployment);
+
+    expect(result.return401).toBe(false);
+  });
+
+  it('should return return401: false when auth-proxy-type annotation has different value', () => {
+    const mockService = mockInferenceServiceK8sResource({ name: 'test-model' });
+    const deployment = {
+      model: {
+        ...mockService,
+        metadata: {
+          ...mockService.metadata,
+          annotations: {
+            ...mockService.metadata.annotations,
+            'security.opendatahub.io/auth-proxy-type': 'other-value',
+          },
+        },
+      } as InferenceServiceKind,
+    };
+
+    const result = extractTimeoutConfig(deployment);
+
+    expect(result.return401).toBe(false);
+  });
+
+  it('should extract both timeout and return401 correctly', () => {
+    const mockService = mockInferenceServiceK8sResource({ name: 'test-model' });
+    const deployment = {
+      model: {
+        ...mockService,
+        spec: {
+          predictor: {
+            timeout: 90,
+            model: {
+              modelFormat: { name: 'onnx' },
+              runtime: 'test-runtime',
+            },
+          },
+        },
+        metadata: {
+          ...mockService.metadata,
+          annotations: {
+            ...mockService.metadata.annotations,
+            'security.opendatahub.io/auth-proxy-type': 'kube-rbac-proxy',
+          },
+        },
+      } as InferenceServiceKind,
+    };
+
+    const result = extractTimeoutConfig(deployment);
+
+    expect(result.timeout).toBe(90);
+    expect(result.return401).toBe(true);
+  });
+});

--- a/packages/kserve/src/deploy.ts
+++ b/packages/kserve/src/deploy.ts
@@ -3,6 +3,7 @@ import type {
   InitialWizardFormData,
   WizardFormData,
 } from '@odh-dashboard/model-serving/types/form-data';
+import type { DeploymentAssemblyFn } from '@odh-dashboard/model-serving/extension-points';
 import { KServeDeployment } from './deployments';
 import { setUpTokenAuth } from './deployUtils';
 import { createServingRuntime } from './deployServer';
@@ -18,6 +19,7 @@ export const deployKServeDeployment = async (
   secretName?: string,
   overwrite?: boolean,
   initialWizardData?: InitialWizardFormData,
+  applyFieldData?: DeploymentAssemblyFn<KServeDeployment>,
 ): Promise<KServeDeployment> => {
   const inferenceServiceData: CreatingInferenceServiceObject = {
     project: projectName,
@@ -57,6 +59,7 @@ export const deployKServeDeployment = async (
     existingDeployment?.model,
     secretName,
     initialWizardData?.transformData,
+    applyFieldData,
     {
       dryRun,
       overwrite,
@@ -75,9 +78,9 @@ export const deployKServeDeployment = async (
     { dryRun: dryRun ?? false },
   );
 
-  return Promise.resolve({
+  return {
     modelServingPlatformId: 'kserve',
     model: inferenceService,
     server: servingRuntime,
-  });
+  };
 };

--- a/packages/kserve/src/deployModel.ts
+++ b/packages/kserve/src/deployModel.ts
@@ -19,6 +19,7 @@ import type { CreateConnectionData } from '@odh-dashboard/model-serving/componen
 import * as _ from 'lodash-es';
 import { applyHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
 import { INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS } from '@odh-dashboard/internal/concepts/hardwareProfiles/const';
+import type { DeploymentAssemblyFn } from '@odh-dashboard/model-serving/extension-points';
 import {
   applyAiAvailableAssetAnnotations,
   applyAuth,
@@ -38,6 +39,8 @@ import {
   updateInferenceService,
 } from './api/inferenceService';
 import { applyModelRuntime } from './deployServer';
+import type { KServeDeployment } from './deployments';
+import { KSERVE_ID } from '../extensions';
 
 export type CreatingInferenceServiceObject = {
   project: string;
@@ -168,18 +171,27 @@ export const deployInferenceService = (
   existingInferenceService?: InferenceServiceKind,
   connectionSecretName?: string,
   transformData?: { metadata?: { labels?: Record<string, string> } },
+  applyFieldData?: DeploymentAssemblyFn<KServeDeployment>,
   opts?: {
     dryRun?: boolean;
     overwrite?: boolean;
   },
 ): Promise<InferenceServiceKind> => {
-  const newInferenceService = assembleInferenceService(
+  let newInferenceService = assembleInferenceService(
     data,
     existingInferenceService,
     opts?.dryRun,
     connectionSecretName,
     transformData,
   );
+
+  if (applyFieldData) {
+    const assembledDeployment = applyFieldData({
+      modelServingPlatformId: KSERVE_ID,
+      model: newInferenceService,
+    });
+    newInferenceService = assembledDeployment.model;
+  }
 
   if (!existingInferenceService) {
     return createInferenceService(newInferenceService, opts);

--- a/packages/kserve/src/wizardFields/timeout/TimeoutField.tsx
+++ b/packages/kserve/src/wizardFields/timeout/TimeoutField.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { Checkbox, FormGroup, StackItem } from '@patternfly/react-core';
+import { z } from 'zod';
+import type { RecursivePartial } from '@odh-dashboard/internal/typeHelpers';
+import type { WizardFormData, WizardField } from '@odh-dashboard/model-serving/types/form-data';
+import NumberInputWrapper from '@odh-dashboard/internal/components/NumberInputWrapper';
+import DashboardHelpTooltip from '@odh-dashboard/internal/concepts/dashboard/DashboardHelpTooltip';
+import {
+  isServingRuntimeKind,
+  isTemplateKind,
+} from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/utils';
+import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { DEFAULT_TIMEOUT } from './timeoutApplyExtract';
+
+export type TimeoutFieldValue = {
+  timeout: number;
+  return401: boolean;
+};
+
+export const timeoutFieldSchema = z.object({
+  timeout: z.number().min(0),
+  return401: z.boolean(),
+});
+
+const setTimeoutFieldData = (value: TimeoutFieldValue): TimeoutFieldValue => value;
+
+const getInitialTimeoutFieldData = (value?: TimeoutFieldValue): TimeoutFieldValue => {
+  if (value) {
+    return value;
+  }
+  return { timeout: DEFAULT_TIMEOUT, return401: false };
+};
+
+/**
+ * Type guard to check if a value is a K8sResourceCommon (has apiVersion and kind).
+ */
+const isK8sResourceCommon = (resource: unknown): resource is K8sResourceCommon =>
+  typeof resource === 'object' &&
+  resource !== null &&
+  'apiVersion' in resource &&
+  'kind' in resource;
+
+/**
+ * Returns true when KServe InferenceService is active.
+ * Active when editing an InferenceService or when a ServingRuntime/Template is selected.
+ */
+export const isKServeInferenceServiceActive = (
+  wizardState: RecursivePartial<WizardFormData['state']>,
+): boolean => {
+  const modelServerData = wizardState.modelServer?.data;
+  if (!modelServerData) {
+    return false;
+  }
+
+  const { template } = modelServerData;
+
+  if (!template || !isK8sResourceCommon(template)) {
+    // Edit mode: has name and namespace but no template
+    return !!(modelServerData.name && modelServerData.namespace);
+  }
+
+  // Check if it's a Template containing a ServingRuntime
+  if (isTemplateKind(template)) {
+    try {
+      return isServingRuntimeKind(template.objects[0]);
+    } catch {
+      return false;
+    }
+  }
+
+  // Check if it's a direct ServingRuntime
+  try {
+    return isServingRuntimeKind(template);
+  } catch {
+    return false;
+  }
+};
+
+type TimeoutFieldProps = {
+  id: string;
+  value: TimeoutFieldValue;
+  onChange: (value: TimeoutFieldValue) => void;
+  isDisabled?: boolean;
+};
+
+const TimeoutFieldComponent: React.FC<TimeoutFieldProps> = ({
+  id,
+  value,
+  onChange,
+  isDisabled,
+}) => (
+  <StackItem data-testid="timeout-field">
+    <FormGroup
+      label="Model route timeout"
+      fieldId={`${id}-timeout`}
+      data-testid="timeout-field-group"
+    >
+      <NumberInputWrapper
+        min={0}
+        max={1000000}
+        value={value.timeout}
+        onChange={(newValue?: number) =>
+          onChange({ ...value, timeout: newValue ?? DEFAULT_TIMEOUT })
+        }
+        increment={5}
+        unit="seconds"
+        isDisabled={isDisabled}
+        data-testid="timeout-input"
+      />
+    </FormGroup>
+    <FormGroup
+      label="Authentication failure handling"
+      fieldId={`${id}-auth-failure`}
+      data-testid="auth-failure-field-group"
+      labelHelp={
+        <DashboardHelpTooltip
+          content={
+            <>
+              If enabled, unauthorized requests will return a 401 Unauthorized status, instead of
+              redirecting to the login page.
+            </>
+          }
+        />
+      }
+    >
+      <Checkbox
+        label="Return 401 API Response"
+        id={`${id}-return-401`}
+        name={`${id}-return-401`}
+        data-testid="return-401-checkbox"
+        isChecked={value.return401}
+        isDisabled={isDisabled}
+        onChange={(e, checked) => onChange({ ...value, return401: checked })}
+      />
+    </FormGroup>
+  </StackItem>
+);
+
+type TimeoutFieldType = WizardField<TimeoutFieldValue>;
+
+export const TIMEOUT_FIELD_ID = 'kserve/timeout';
+
+export const TimeoutFieldWizardField: TimeoutFieldType = {
+  id: TIMEOUT_FIELD_ID,
+  step: 'advancedOptions',
+  type: 'addition',
+  isActive: isKServeInferenceServiceActive,
+  reducerFunctions: {
+    setFieldData: setTimeoutFieldData,
+    getInitialFieldData: getInitialTimeoutFieldData,
+    validationSchema: timeoutFieldSchema,
+  },
+  component: TimeoutFieldComponent,
+};

--- a/packages/kserve/src/wizardFields/timeout/timeoutApplyExtract.ts
+++ b/packages/kserve/src/wizardFields/timeout/timeoutApplyExtract.ts
@@ -1,0 +1,84 @@
+import type { InferenceServiceKind } from '@odh-dashboard/internal/k8sTypes';
+import { TimeoutFieldValue } from './TimeoutField';
+import { KServeDeployment } from '../../deployments';
+
+export type TimeoutConfigFieldData = {
+  timeout?: number;
+  return401?: boolean;
+};
+
+export const DEFAULT_TIMEOUT = 30;
+
+export const applyTimeoutConfig = (
+  inferenceService: InferenceServiceKind,
+  timeoutConfig?: TimeoutConfigFieldData,
+): InferenceServiceKind => {
+  if (!timeoutConfig) {
+    return inferenceService;
+  }
+
+  const result = structuredClone(inferenceService);
+
+  if (!result.metadata.annotations) {
+    result.metadata.annotations = {};
+  }
+
+  // Clear existing auth-proxy-type for update scenarios
+  delete result.metadata.annotations['security.opendatahub.io/auth-proxy-type'];
+
+  // Set timeout (spread will overwrite any existing timeout value)
+  if (timeoutConfig.timeout !== undefined) {
+    result.spec.predictor = {
+      ...result.spec.predictor,
+      timeout: timeoutConfig.timeout,
+    };
+  }
+
+  // Set auth-proxy-type if return401 is true
+  if (timeoutConfig.return401) {
+    result.metadata.annotations['security.opendatahub.io/auth-proxy-type'] = 'kube-rbac-proxy';
+  }
+
+  return result;
+};
+
+export const extractTimeoutConfig = (deployment: {
+  model: InferenceServiceKind;
+}): TimeoutConfigFieldData => {
+  const { timeout } = deployment.model.spec.predictor;
+  const authProxyType =
+    deployment.model.metadata.annotations?.['security.opendatahub.io/auth-proxy-type'];
+
+  return {
+    timeout: timeout ?? DEFAULT_TIMEOUT,
+    return401: authProxyType === 'kube-rbac-proxy',
+  };
+};
+
+/**
+ * Apply timeout field data to a KServe deployment during assembly
+ */
+export const applyTimeoutFieldData = (
+  deployment: KServeDeployment,
+  fieldData: TimeoutFieldValue,
+): KServeDeployment => {
+  const updatedModel = applyTimeoutConfig(deployment.model, {
+    timeout: fieldData.timeout,
+    return401: fieldData.return401,
+  });
+  return {
+    ...deployment,
+    model: updatedModel,
+  };
+};
+
+/**
+ * Extract timeout field data from an existing KServe deployment
+ */
+export const extractTimeoutFieldData = (deployment: KServeDeployment): TimeoutFieldValue => {
+  const config = extractTimeoutConfig(deployment);
+  return {
+    timeout: config.timeout ?? DEFAULT_TIMEOUT,
+    return401: config.return401 ?? false,
+  };
+};

--- a/packages/model-serving/src/components/deploymentWizard/fields/GenericFieldRenderer.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/GenericFieldRenderer.tsx
@@ -4,16 +4,24 @@ import type { UseModelDeploymentWizardState } from '../useDeploymentWizard';
 
 type GenericFieldRendererProps = {
   wizardState: UseModelDeploymentWizardState;
-  parentId: string;
+  parentId?: string;
+  fieldId?: string;
 };
 
 export const GenericFieldRenderer: React.FC<GenericFieldRendererProps> = ({
   parentId,
   wizardState,
+  fieldId,
 }) => {
   const fields: WizardField<unknown>[] = React.useMemo(() => {
-    return wizardState.fields.filter((f) => f.parentId === parentId);
-  }, [parentId, wizardState.fields]);
+    if (fieldId) {
+      return wizardState.fields.filter((f) => f.id === fieldId);
+    }
+    if (parentId) {
+      return wizardState.fields.filter((f) => f.parentId === parentId);
+    }
+    return [];
+  }, [parentId, fieldId, wizardState.fields]);
 
   return (
     <>

--- a/packages/model-serving/src/components/deploymentWizard/steps/AdvancedOptionsStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/AdvancedOptionsStep.tsx
@@ -13,6 +13,7 @@ import { TokenAuthenticationField } from '../fields/TokenAuthenticationField';
 import { RuntimeArgsField } from '../fields/RuntimeArgsField';
 import { EnvironmentVariablesField } from '../fields/EnvironmentVariablesField';
 import { DeploymentStrategyField } from '../fields/DeploymentStrategyField';
+import { GenericFieldRenderer } from '../fields/GenericFieldRenderer';
 import { type UseModelDeploymentWizardState } from '../useDeploymentWizard';
 import { AvailableAiAssetsFieldsComponent } from '../fields/ModelAvailabilityFields';
 import { showAuthWarning } from '../hooks/useAuthWarning';
@@ -206,6 +207,7 @@ export const AdvancedSettingsStepContent: React.FC<AdvancedSettingsStepContentPr
                 </FormGroup>
               </StackItem>
             )}
+            <GenericFieldRenderer fieldId="kserve/timeout" wizardState={wizardState} />
           </Stack>
         </FormSection>
       </Form>


### PR DESCRIPTION
* Cherry pick timeout field

* Make it work for 3.3

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Downstream cherry pick for https://redhat.atlassian.net/browse/RHOAIENG-51802

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
