### PR TITLE
Remove unnecessary USER 0/USER 1001 from Dockerfile.konflux BFF stages

### DIFF
--- a/Dockerfile.konflux.eval-hub
+++ b/Dockerfile.konflux.eval-hub
@@ -57,8 +57,6 @@ RUN npm run build:prod
 # BFF build stage
 FROM ${GOLANG_BASE_IMAGE} AS bff-builder
 
-USER 0
-
 ARG BFF_SOURCE_CODE
 ARG TARGETOS
 ARG TARGETARCH
@@ -79,7 +77,6 @@ COPY ${BFF_SOURCE_CODE}/openapi/ openapi/
 # Build the Go application
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o bff ./cmd
 
-USER 1001
 # Final stage
 FROM ${DISTROLESS_BASE_IMAGE}
 

--- a/Dockerfile.konflux.genai
+++ b/Dockerfile.konflux.genai
@@ -57,8 +57,6 @@ RUN npm run build:prod
 # BFF build stage
 FROM ${GOLANG_BASE_IMAGE} AS bff-builder
 
-USER 0
-
 ARG BFF_SOURCE_CODE
 ARG TARGETOS
 ARG TARGETARCH
@@ -79,7 +77,6 @@ COPY ${BFF_SOURCE_CODE}/openapi/ openapi/
 # Build the Go application
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o bff ./cmd
 
-USER 1001
 # Final stage
 FROM ${DISTROLESS_BASE_IMAGE}
 

--- a/Dockerfile.konflux.maas
+++ b/Dockerfile.konflux.maas
@@ -62,8 +62,6 @@ RUN npm run build:prod
 # BFF build stage
 FROM ${GOLANG_BASE_IMAGE} AS bff-builder
 
-USER 0
-
 ARG BFF_SOURCE_CODE
 ARG TARGETOS
 ARG TARGETARCH
@@ -83,7 +81,6 @@ COPY ${BFF_SOURCE_CODE}/internal/ internal/
 # Build the Go application
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o bff ./cmd
 
-USER 1001
 # Final stage
 FROM ${DISTROLESS_BASE_IMAGE}
 

--- a/Dockerfile.konflux.mlflow
+++ b/Dockerfile.konflux.mlflow
@@ -57,8 +57,6 @@ RUN npm run build:prod
 # BFF build stage
 FROM ${GOLANG_BASE_IMAGE} AS bff-builder
 
-USER 0
-
 ARG BFF_SOURCE_CODE
 ARG TARGETOS
 ARG TARGETARCH
@@ -78,7 +76,6 @@ COPY ${BFF_SOURCE_CODE}/internal/ internal/
 # Build the Go application
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o bff ./cmd
 
-USER 1001
 # Final stage
 FROM ${DISTROLESS_BASE_IMAGE}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-57524

## Description

Removes `USER 0` and `USER 1001` directives from the BFF builder stage in four `Dockerfile.konflux.*` files to match the consistent pattern used by `automl`, `autorag`, and `modelregistry`.

The `USER 0` pattern was introduced in commit `8e8452129` (2025-10-17) in `Dockerfile.konflux.genai`, likely to fix a local build issue with Podman rootless or legacy Docker (non-BuildKit). Subsequent Dockerfiles (`maas`, `mlflow`, `eval-hub`) copied the pattern, while others did not — creating inconsistency.

**Why this is unnecessary for Konflux:**
- The `Dockerfile.konflux.*` pipelines are only triggered on-demand (via `/build-konflux-*` comments or `kfbuild-*` labels), not on every PR
- Konflux runs Buildah in privileged pods, which creates WORKDIR owned by the current user (like BuildKit) — no permission issue exists
- The everyday CI uses `Dockerfile.workspace` files, not `Dockerfile.konflux.*`

**Files updated** (removed `USER 0` before bff-builder WORKDIR and `USER 1001` after go build):
- `Dockerfile.konflux.genai`
- `Dockerfile.konflux.maas`
- `Dockerfile.konflux.mlflow`
- `Dockerfile.konflux.eval-hub`

**Files already consistent** (no changes needed):
- `Dockerfile.konflux.automl`
- `Dockerfile.konflux.autorag`
- `Dockerfile.konflux.modelregistry`

## How Has This Been Tested?

Verified that no `USER 0` or `USER 1001` directives remain in the BFF builder stages of the affected files. Confirmed that all `Dockerfile.konflux.*` BFF builder stages now follow the same pattern (no USER switching). Full build verification will happen via on-demand Konflux pipeline (`/build-konflux-*`).

## Test Impact

No tests applicable — this is a Dockerfile-only change removing unnecessary directives. The Konflux build pipelines will validate the Dockerfiles build correctly.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`