### PR TITLE
fix(backend): add tslib as explicit production dependency

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -55,6 +55,7 @@
     "js-yaml": "^4.2.0",
     "lodash": "^4.18.1",
     "pino": "^9.14.0",
+    "tslib": "^2.8.1",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "js-yaml": "^4.2.0",
         "lodash": "^4.18.1",
         "pino": "^9.14.0",
+        "tslib": "^2.8.1",
         "ws": "^8.21.0"
       },
       "devDependencies": {


### PR DESCRIPTION
Cherry-pick of https://github.com/opendatahub-io/odh-dashboard/pull/8232 onto `rhoai-3.5-ea.2`.

https://issues.redhat.com/browse/RHOAIENG-70441

## Description

`tslib` is required at runtime because the shared tsconfig (`packages/tsconfig/tsconfig.json`) sets `importHelpers: true`, which causes `tsc` to emit `require('tslib')` at the top of every compiled file instead of inlining TypeScript helpers.

### Root cause chain

**Step 1 — latent bug (PR #7958, June 15):** `prom-client` was removed from `backend/package.json`. Previously, `prom-client` provided `tslib` transitively.

**Step 2 — trigger (PR #8213, June 19 14:58 UTC):** ["revert frontend update to patternfly 6.5"](https://github.com/opendatahub-io/odh-dashboard/pull/8213) regenerated `package-lock.json` with PatternFly 6.4 in place. This shifted the hoisted `node_modules/tslib` from `1.14.1` to `2.8.1`. In the Docker production build, `npm install --omit=dev` prunes the dev PatternFly packages — leaving tslib with no declared production consumer accessible to the backend. Node.js module resolution from `backend/dist/server.js` cannot find `tslib` and crashes:

```
Error: Cannot find module 'tslib'
Require stack:
- /usr/src/app/backend/dist/server.js
```

This was confirmed on the cluster — `rhods-dashboard` pods are in `CrashLoopBackOff` (84+ restarts) in `redhat-ods-applications`. The affected image: `registry.redhat.io/rhoai/odh-dashboard-rhel9@sha256:ba0744e4583c564ddd8a21feeee827b548b119a48e915ec97806e048211d25e2`.

### Fix

Declare `tslib` explicitly in `backend/package.json` `dependencies` so it is always hoisted to the root `node_modules/` and accessible to the compiled backend, regardless of which transitive packages happen to pull it in.

## How Has This Been Tested?

- Confirmed the crash from live cluster logs
- Early-gate build for upstream PR #8232 succeeded: `quay.io/opendatahub/opendatahub-operator-catalog:odh-pr-8232-odh-dashboard@sha256:f12be8ece4965d09eaf4e6f85ca9898219e2602b008e289b67ed748b1c587bc8`
- Upstream PR #8232 passed Phase 4 (Operator Integration) confirming the pod starts correctly with this fix

## Test Impact

No new tests required — this is a dependency declaration fix for a missing runtime module.

## Request review criteria:

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:

- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)