### PR TITLE
RHOAIENG-65724: Add Dockerfile.konflux.dashboard-operator

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,6 @@ tests/
 **/__tests__/
 scripts/
 !scripts/prepare-production-manifest.js
-manifests/
 
 # Local .env images
 **/.env.development

--- a/Dockerfile.konflux.dashboard-operator
+++ b/Dockerfile.konflux.dashboard-operator
@@ -14,7 +14,7 @@ COPY dashboard-operator/cmd/ cmd/
 COPY dashboard-operator/api/ api/
 COPY dashboard-operator/internal/ internal/
 
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/manager ./cmd/manager
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/manager ./cmd/manager
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:1bc3c5c15720506a0cf48adfdf8b623dfe704377e007d7bbae8d14876392ca6a
 

--- a/Dockerfile.konflux.dashboard-operator
+++ b/Dockerfile.konflux.dashboard-operator
@@ -1,0 +1,38 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:ebcc3560ec892af7c081bcfbef9959fe54c4b1603dc1f6c6e1494992f6c71f89 AS builder
+
+USER root
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /usr/src/app
+
+COPY dashboard-operator/go.mod dashboard-operator/go.sum ./
+RUN go mod download
+
+COPY dashboard-operator/cmd/ cmd/
+COPY dashboard-operator/api/ api/
+COPY dashboard-operator/internal/ internal/
+
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/manager ./cmd/manager
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:1bc3c5c15720506a0cf48adfdf8b623dfe704377e007d7bbae8d14876392ca6a
+
+WORKDIR /
+
+COPY --from=builder /tmp/manager .
+COPY manifests/ /opt/manifests/dashboard/
+
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]
+
+LABEL com.redhat.component="odh-dashboard-operator-container" \
+      name="managed-open-data-hub/odh-dashboard-operator-rhel9" \
+      description="odh-dashboard-operator" \
+      summary="odh-dashboard-operator" \
+      maintainer="['managed-open-data-hub@redhat.com']" \
+      io.openshift.expose-services="" \
+      io.k8s.display-name="odh-dashboard-operator" \
+      io.k8s.description="odh-dashboard-operator" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"


### PR DESCRIPTION
Supersedes #2061 — rebased on latest `main` and addresses all review feedback.

Adds the downstream Konflux Dockerfile for the dashboard-operator component to `main` so it propagates to future release branches.

## Changes from #2061

- **Go 1.26** — Bumps `go-toolset` from 1.25 to 1.26, SHA-pinned. Aligns with the other Go 1.26 modules in the repo (`automl`, `eval-hub`, `autorag`, `maas`, `mlflow` BFFs, `agent-ops`).
- **Cross-architecture support** — Adds `TARGETOS`/`TARGETARCH` build args matching the `agent-ops` Dockerfile pattern ([liday-rh review](https://github.com/red-hat-data-services/odh-dashboard/pull/2061#discussion_r2153116804)).
- **Security hardening** — Removes `chmod -R g+w` on manifests. The operator only reads manifests at runtime; `COPY` preserves readable permissions. Group-write on read-only data is unnecessary attack surface ([liday-rh review](https://github.com/red-hat-data-services/odh-dashboard/pull/2061#discussion_r2153116792)).
- **Smaller binary** — Adds `-ldflags="-s -w"` to strip debug symbols.
- **Fix `.dockerignore`** — Removes `manifests/` from root `.dockerignore`. When Tekton copies the Dockerfile to a temp location, buildah falls back to the root `.dockerignore` instead of `dashboard-operator/Dockerfile.dockerignore`, causing: `no items matching glob "manifests" copied (1 filtered out)`.
- **Label alignment** — Updated `name` field to use `rhel9` suffix per @christianvogt's feedback.

## FIPS compliance

Uses `CGO_ENABLED=1` and `-tags strictfipsruntime` for FIPS-compliant builds, matching other Konflux Dockerfiles.

## Base images (SHA-pinned)

- `ubi9/go-toolset:1.26@sha256:ebcc3560ec892af7c081bcfbef9959fe54c4b1603dc1f6c6e1494992f6c71f89`
- `ubi9/ubi-minimal@sha256:1bc3c5c15720506a0cf48adfdf8b623dfe704377e007d7bbae8d14876392ca6a`

Sister upstream PR: https://github.com/opendatahub-io/odh-dashboard/pull/8239

Jira: https://issues.redhat.com/browse/RHOAIENG-65724