### PR TITLE
Add Dockerfile.konflux.core-bff for RHOAI Konflux builds

### DIFF
--- a/Dockerfile.konflux.core-bff
+++ b/Dockerfile.konflux.core-bff
@@ -1,0 +1,103 @@
+# Multi-stage workspace-aware Dockerfile for core-bff distribution
+# Build from repository root: docker build --file ./Dockerfile.konflux.core-bff .
+
+# Source code arguments
+ARG MODULE_NAME=core-bff
+ARG UI_SOURCE_CODE=./distributions/${MODULE_NAME}/frontend
+ARG BFF_SOURCE_CODE=./distributions/${MODULE_NAME}/bff
+
+# Set the base images for the build stages
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22@sha256:a83e4ae4bef9954136fdd4718448620b1f49338031c8a0ee4d8adb2a1bf3c1af
+ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e
+ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal@sha256:463cae32c6f6f5594b11a5c22de275016bd8545ce58a6373388e8b24f13fc15c
+
+# UI build stage
+FROM ${NODE_BASE_IMAGE} AS ui-builder
+
+ARG UI_SOURCE_CODE
+ARG MODULE_NAME
+ARG DEPLOYMENT_MODE
+ARG PLATFORM_MODE
+
+WORKDIR /usr/src/workspace
+
+### Workspace setup
+# Copy root workspace manifest first (allows npm to compute workspace graph)
+COPY --chown=default:root package.json package-lock.json* ./
+# Copy the frontend workspace manifest so its dependencies can be resolved if referenced
+COPY --chown=default:root frontend/package.json ./frontend/
+# Copy required shared workspace packages needed for module builds
+COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
+COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
+# Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
+COPY --chown=default:root frontend/src/ ./frontend/src/
+
+# Copy the specific module source code
+COPY --chown=default:root ${UI_SOURCE_CODE} ./${UI_SOURCE_CODE}
+
+# Change file ownership to the assemble user
+USER default
+
+# Install workspace dependencies first (this creates node_modules at workspace level)
+RUN npm cache clean --force
+# Install all workspace dependencies (includes root + any copied workspaces)
+RUN npm ci --omit=optional --ignore-scripts
+
+# Set up the specific module
+WORKDIR /usr/src/workspace/${UI_SOURCE_CODE}
+
+# Install module dependencies
+RUN npm ci --omit=optional --ignore-scripts
+
+# Build the module
+RUN npm run build:prod
+
+# BFF build stage
+FROM ${GOLANG_BASE_IMAGE} AS bff-builder
+
+ARG BFF_SOURCE_CODE
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /usr/src/app
+
+# Copy the Go Modules manifests
+COPY ${BFF_SOURCE_CODE}/go.mod ${BFF_SOURCE_CODE}/go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy the go source files
+COPY ${BFF_SOURCE_CODE}/cmd/ cmd/
+COPY ${BFF_SOURCE_CODE}/internal/ internal/
+COPY ${BFF_SOURCE_CODE}/openapi/ openapi/
+
+# Build the Go application
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o bff ./cmd
+
+# Final stage
+FROM ${DISTROLESS_BASE_IMAGE}
+
+ARG UI_SOURCE_CODE
+
+WORKDIR /
+COPY --from=bff-builder /usr/src/app/bff ./
+COPY --from=bff-builder /usr/src/app/openapi/ ./openapi/
+COPY --from=ui-builder /usr/src/workspace/${UI_SOURCE_CODE}/dist ./static/
+USER 65532:65532
+
+# Expose port 8080
+EXPOSE 8080
+
+ENTRYPOINT ["/bff"]
+
+LABEL com.redhat.component="odh-core-bff-container" \
+      name="managed-open-data-hub/odh-core-bff-rhel9" \
+      description="odh-core-bff" \
+      summary="odh-core-bff" \
+      maintainer="['managed-open-data-hub@redhat.com']" \
+      io.openshift.expose-services="" \
+      io.k8s.display-name="odh-core-bff" \
+      io.k8s.description="odh-core-bff" \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"


### PR DESCRIPTION
## Summary

Adds the downstream Konflux Dockerfile for the **core-bff** distribution component (`distributions/core-bff/`).

- SHA-pinned UBI9 base images (Node.js 22, Go 1.25 toolset, UBI9-minimal)
- FIPS-compliant build flags (`CGO_ENABLED=1 -tags strictfipsruntime`)
- Red Hat labels on final stage
- Uses `distributions/core-bff/` paths (distribution, not a packages/ module)
- Matches upstream `distributions/core-bff/Dockerfile.workspace` structure

## Notes

- Digests will be kept up to date by Renovate once DevOps onboarding completes
- Related upstream work tracked in RHOAIENG-72842