### PR TITLE
fix(e2e): use metrics endpoint for feature store overview card assertion

### DIFF
--- a/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
@@ -11,7 +11,10 @@ import {
 } from '../../../utils/oc_commands/featureStoreResources';
 import { retryableBefore } from '../../../utils/retryableHooks';
 import { generateTestUUID } from '../../../utils/uuidGenerator';
-import { getAllFeatureStoreCounts } from '../../../utils/api/featureStoreRest';
+import {
+  getAllFeatureStoreCounts,
+  getMetricsResourceCounts,
+} from '../../../utils/api/featureStoreRest';
 import { featureMetricsOverview } from '../../../pages/featureStore/featureMetrics';
 import { getCustomResource } from '../../../utils/oc_commands/customResources';
 
@@ -24,6 +27,12 @@ describe('Feature Store Page Validation', () => {
   let dataSourceCount: number;
   let featureViewCount: number;
   let featureServiceCount: number;
+  let metricsFeatureCount: number;
+  let metricsEntityCount: number;
+  let metricsDatasetCount: number;
+  let metricsDataSourceCount: number;
+  let metricsFeatureViewCount: number;
+  let metricsFeatureServiceCount: number;
   let skipTest = false;
   const uuid = generateTestUUID();
 
@@ -65,18 +74,29 @@ describe('Feature Store Page Validation', () => {
         .then(() => {
           // Create route and fetch counts for the Feast instance
           return createRouteAndGetUrl(projectName, testData.feastInstanceName).then((routeUrl) => {
-            return getAllFeatureStoreCounts(routeUrl, testData.feastCreditScoringProject).then(
-              (feastInstanceCounts) => {
-                // Assign all counts from the returned object
-                featureCount = feastInstanceCounts.featureCount;
-                entityCount = feastInstanceCounts.entityCount;
-                datasetCount = feastInstanceCounts.datasetCount;
-                dataSourceCount = feastInstanceCounts.dataSourceCount;
-                featureViewCount = feastInstanceCounts.featureViewCount;
-                featureServiceCount = feastInstanceCounts.featureServiceCount;
+            return getMetricsResourceCounts(routeUrl, testData.feastCreditScoringProject).then(
+              (metricsCounts) => {
+                metricsFeatureCount = metricsCounts.featureCount;
+                metricsEntityCount = metricsCounts.entityCount;
+                metricsDatasetCount = metricsCounts.datasetCount;
+                metricsDataSourceCount = metricsCounts.dataSourceCount;
+                metricsFeatureViewCount = metricsCounts.featureViewCount;
+                metricsFeatureServiceCount = metricsCounts.featureServiceCount;
 
-                cy.log('Counts assigned successfully:', feastInstanceCounts);
-                return cy.wrap(feastInstanceCounts);
+                return getAllFeatureStoreCounts(routeUrl, testData.feastCreditScoringProject).then(
+                  (listCounts) => {
+                    featureCount = listCounts.featureCount;
+                    entityCount = listCounts.entityCount;
+                    datasetCount = listCounts.datasetCount;
+                    dataSourceCount = listCounts.dataSourceCount;
+                    featureViewCount = listCounts.featureViewCount;
+                    featureServiceCount = listCounts.featureServiceCount;
+
+                    cy.log(`Metrics counts: ${JSON.stringify(metricsCounts)}`);
+                    cy.log(`List counts: ${JSON.stringify(listCounts)}`);
+                    return cy.wrap({ metricsCounts, listCounts });
+                  },
+                );
               },
             );
           });
@@ -108,11 +128,14 @@ describe('Feature Store Page Validation', () => {
       featureStoreGlobal.navigateToOverview();
       featureStoreGlobal.selectProject(testData.feastCreditScoringProject);
       cy.step(`Verify Metrics contents count is displayed correctly`);
-      featureMetricsOverview.findEntitiesCard().should('contain.text', entityCount);
-      featureMetricsOverview.findDataSourcesCard().should('contain.text', dataSourceCount);
-      featureMetricsOverview.findSavedDatasetsCard().should('contain.text', datasetCount);
-      featureMetricsOverview.findFeaturesCard().should('contain.text', featureCount);
-      featureMetricsOverview.findFeatureServicesCard().should('contain.text', featureServiceCount);
+      featureMetricsOverview.findEntitiesCard().should('contain.text', metricsEntityCount);
+      featureMetricsOverview.findDataSourcesCard().should('contain.text', metricsDataSourceCount);
+      featureMetricsOverview.findSavedDatasetsCard().should('contain.text', metricsDatasetCount);
+      featureMetricsOverview.findFeaturesCard().should('contain.text', metricsFeatureCount);
+      featureMetricsOverview.findFeatureViewsCard().should('contain.text', metricsFeatureViewCount);
+      featureMetricsOverview
+        .findFeatureServicesCard()
+        .should('contain.text', metricsFeatureServiceCount);
 
       cy.step(`Navigate to the Feature Store Entities page`);
       featureStoreGlobal.navigateToEntities();

--- a/packages/cypress/cypress/utils/api/featureStoreRest.ts
+++ b/packages/cypress/cypress/utils/api/featureStoreRest.ts
@@ -170,7 +170,58 @@ export const getDatasetsCount = (routeUrl: string, project: string): Cypress.Cha
 };
 
 /**
- * Fetches all Feature Store counts in a single function call
+ * Fetches resource counts from the metrics endpoint (same source the dashboard overview cards use)
+ *
+ * @param {string} routeUrl - The Feature Store route URL
+ * @param {string} project - The project name
+ * @returns {Cypress.Chainable<object>} Object containing all counts from the metrics endpoint
+ */
+export const getMetricsResourceCounts = (
+  routeUrl: string,
+  project: string,
+): Cypress.Chainable<{
+  featureCount: number;
+  entityCount: number;
+  datasetCount: number;
+  dataSourceCount: number;
+  featureViewCount: number;
+  featureServiceCount: number;
+}> => {
+  const apiUrl = `${routeUrl}/api/v1/metrics/resource_counts?project=${encodeURIComponent(
+    project,
+  )}`;
+
+  return cy
+    .request({
+      method: 'GET',
+      url: apiUrl,
+      headers: { accept: 'application/json' },
+      failOnStatusCode: false,
+    })
+    .then((response) => {
+      if (response.status !== 200 || !response.body || !('counts' in response.body)) {
+        throw new Error(`Failed to get metrics resource counts: ${response.status}`);
+      }
+      const { counts } = response.body;
+      if (typeof counts.features !== 'number' || typeof counts.entities !== 'number') {
+        throw new Error(`Unexpected metrics response shape: ${JSON.stringify(counts)}`);
+      }
+      const allCounts = {
+        featureCount: counts.features,
+        entityCount: counts.entities,
+        datasetCount: counts.savedDatasets,
+        dataSourceCount: counts.dataSources,
+        featureViewCount: counts.featureViews,
+        featureServiceCount: counts.featureServices,
+      };
+
+      cy.log(`Metrics resource counts fetched: ${JSON.stringify(allCounts)}`);
+      return cy.wrap(allCounts);
+    });
+};
+
+/**
+ * Fetches all Feature Store counts from individual list endpoints (for page pagination validation)
  * @param {string} routeUrl - The route URL for the API
  * @param {string} project - The project name
  * @returns {Cypress.Chainable<object>} Object containing all counts


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72339

## Description

Cherry-pick of [fix(e2e): use metrics endpoint for feature store overview card assertions (#8331)](https://github.com/opendatahub-io/odh-dashboard/pull/8331) to `rhoai-3.5-ea.2`.

The feature store overview card assertions in the E2E test were comparing counts fetched from individual **list endpoints** (e.g. `/api/v1/features`, `/api/v1/entities`, etc.) against what the dashboard **overview cards** display. However, the overview cards source their numbers from the **metrics endpoint** (`/api/v1/metrics/resource_counts`), which can return different values. This mismatch caused flaky or incorrect test failures.

**Changes:**

- Added a new `getMetricsResourceCounts()` utility in `featureStoreRest.ts` that calls the `/api/v1/metrics/resource_counts` endpoint — the same source the dashboard overview cards use.
- Updated `testFeatureStoreFeatures.cy.ts` to fetch counts from the metrics endpoint in addition to the list endpoints, and use the metrics counts when asserting the overview card values.
- Added a `findFeatureViewsCard()` assertion to the overview card checks, which was previously missing.
- The project name is now `encodeURIComponent`-encoded in the metrics API URL to handle special characters correctly.
- Added a shape guard on the metrics response to surface unexpected API shapes early with a clear error.

## How Has This Been Tested?

- Tested on main in the original PR via CI.
- Cherry-pick applied cleanly to `rhoai-3.5-ea.2` with no conflicts.

## Test Impact

- Fixes flaky/incorrect feature store overview card count assertions in `testFeatureStoreFeatures.cy.ts`.
- No new tests added; existing test coverage corrected.

---

## Request review criteria:

Self checklist (all need to be checked):

- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our Best Practices (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:

- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `rhoai-3.5-ea.2`