### PR TITLE
RHOAIENG-72362: Extract genRandomChars to @odh-dashboard/foundation

### DIFF
--- a/Dockerfile.konflux.agent-ops
+++ b/Dockerfile.konflux.agent-ops
@@ -31,6 +31,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/

--- a/Dockerfile.konflux.automl
+++ b/Dockerfile.konflux.automl
@@ -31,6 +31,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/

--- a/Dockerfile.konflux.autorag
+++ b/Dockerfile.konflux.autorag
@@ -31,6 +31,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/

--- a/Dockerfile.konflux.core-bff
+++ b/Dockerfile.konflux.core-bff
@@ -30,6 +30,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 

--- a/Dockerfile.konflux.eval-hub
+++ b/Dockerfile.konflux.eval-hub
@@ -31,6 +31,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/

--- a/Dockerfile.konflux.genai
+++ b/Dockerfile.konflux.genai
@@ -31,6 +31,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/

--- a/Dockerfile.konflux.maas
+++ b/Dockerfile.konflux.maas
@@ -31,6 +31,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy packages required for @odh-dashboard/llmd-serving and its dependencies
 COPY --chown=default:root packages/llmd-serving/ ./packages/llmd-serving/

--- a/Dockerfile.konflux.mlflow
+++ b/Dockerfile.konflux.mlflow
@@ -31,6 +31,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/

--- a/Dockerfile.konflux.modelregistry
+++ b/Dockerfile.konflux.modelregistry
@@ -31,6 +31,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-72362

## Description

Upstream PR opendatahub-io#8359 creates a new `@odh-dashboard/foundation` package (tier 0, zero internal dependencies) and adds `COPY` lines to all `Dockerfile.workspace` files. This commit mirrors that change across the 9 downstream `Dockerfile.konflux.*` files to avoid Konflux build failures — same class of break as the k8s-core and ui-core incidents.

## Test plan

 - [ ] Verify Konflux builds pass for affected modules

## Test Impact

Mechanical change — each file receives one identical `COPY` line inserted after the existing `packages/k8s-core/` COPY, matching the upstream `Dockerfile.workspace` pattern. The existing build pipeline exercises and verifies this.


Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
