### PR TITLE
Add downstream on-pull-request Tekton pipelines and unify /build-konflux trigger

### DIFF
--- a/.tekton/odh-dashboard-pull-request.yaml
+++ b/.tekton/odh-dashboard-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux$|^/build-konflux-odh-dashboard"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-odh-dashboard]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"

--- a/.tekton/odh-mod-arch-automl-pull-request.yaml
+++ b/.tekton/odh-mod-arch-automl-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux-automl"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux$|^/build-konflux-automl"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-automl]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"

--- a/.tekton/odh-mod-arch-autorag-pull-request.yaml
+++ b/.tekton/odh-mod-arch-autorag-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux-autorag"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux$|^/build-konflux-autorag"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-autorag]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"

--- a/.tekton/odh-mod-arch-eval-hub-rhoai-pull-request.yaml
+++ b/.tekton/odh-mod-arch-eval-hub-rhoai-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux-eval-hub"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux$|^/build-konflux-eval-hub"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-eval-hub]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"

--- a/.tekton/odh-mod-arch-eval-hub-rhoai-pull-request.yaml
+++ b/.tekton/odh-mod-arch-eval-hub-rhoai-pull-request.yaml
@@ -1,0 +1,87 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux-eval-hub"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-eval-hub]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-mod-arch-eval-hub
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-mod-arch-eval-hub-on-pull-request-83741
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-mod-arch-eval-hub
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-mod-arch-eval-hub-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile.konflux.eval-hub
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: |
+      [
+        {
+          "path": ".",
+          "type": "npm"
+        },
+        {
+          "path": "packages/eval-hub/frontend",
+          "type": "npm"
+        },
+        {
+          "path": "packages/eval-hub/bff",
+          "type": "gomod"
+        }
+      ]
+  - name: build-image-index
+    value: true
+  - name: enable-slack-failure-notification
+    value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-mod-arch-gen-ai-pull-request.yaml
+++ b/.tekton/odh-mod-arch-gen-ai-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux-gen-ai"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux$|^/build-konflux-gen-ai"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-gen-ai]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"

--- a/.tekton/odh-mod-arch-maas-pull-request.yaml
+++ b/.tekton/odh-mod-arch-maas-pull-request.yaml
@@ -1,0 +1,87 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux-maas"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-maas]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-mod-arch-maas
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-mod-arch-maas-on-pull-request-83741
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-mod-arch-maas
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-mod-arch-maas-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile.konflux.maas
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: |
+      [
+        {
+          "path": ".",
+          "type": "npm"
+        },
+        {
+          "path": "packages/maas/frontend",
+          "type": "npm"
+        },
+        {
+          "path": "packages/maas/bff",
+          "type": "gomod"
+        }
+      ]
+  - name: build-image-index
+    value: true
+  - name: enable-slack-failure-notification
+    value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-mod-arch-maas-pull-request.yaml
+++ b/.tekton/odh-mod-arch-maas-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux-maas"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux$|^/build-konflux-maas"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-maas]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"

--- a/.tekton/odh-mod-arch-mlflow-rhoai-pull-request.yaml
+++ b/.tekton/odh-mod-arch-mlflow-rhoai-pull-request.yaml
@@ -1,0 +1,73 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux-mlflow"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-mlflow]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-mod-arch-mlflow
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-mod-arch-mlflow-on-pull-request-83741
+  namespace: rhoai-tenant
+spec:
+  timeouts:
+    pipeline: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: additional-tags
+    value:
+    - 'pr-{{pull_request_number}}-into-{{target_branch}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-mod-arch-mlflow
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-mod-arch-mlflow-{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile.konflux.mlflow
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: true
+  - name: prefetch-input
+    value: '[{"path":".","type":"npm"},{"path":"packages/mlflow/frontend","type":"npm"},{"path":"packages/mlflow/bff","type":"gomod"}]'
+  - name: build-image-index
+    value: true
+  - name: enable-slack-failure-notification
+    value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-mod-arch-mlflow-rhoai-pull-request.yaml
+++ b/.tekton/odh-mod-arch-mlflow-rhoai-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux-mlflow"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux$|^/build-konflux-mlflow"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-mlflow]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"

--- a/.tekton/odh-mod-arch-model-registry-pull-request.yaml
+++ b/.tekton/odh-mod-arch-model-registry-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux$|^/build-konflux-model-registry"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-odh-dashboard]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"


### PR DESCRIPTION
## Summary
- Add 3 new rhoai-tenant pull-request pipeline files for images that were missing them:
  - `odh-mod-arch-eval-hub-rhoai-pull-request.yaml`
  - `odh-mod-arch-maas-pull-request.yaml`
  - `odh-mod-arch-mlflow-rhoai-pull-request.yaml`
- Update `on-comment` regex on all 8 downstream PR pipelines so a single `/build-konflux` comment triggers all images

## Comment triggers

| Comment | What triggers |
|---------|--------------|
| `/build-konflux` | All 8 images |
| `/build-konflux-odh-dashboard` | odh-dashboard only |
| `/build-konflux-model-registry` | model-registry only |
| `/build-konflux-automl` | automl only |
| `/build-konflux-autorag` | autorag only |
| `/build-konflux-gen-ai` | gen-ai only |
| `/build-konflux-eval-hub` | eval-hub only |
| `/build-konflux-maas` | maas only |
| `/build-konflux-mlflow` | mlflow only |

Params (dockerfile, prefetch-input, build-platforms) for new files are derived from each image's corresponding v3-4-push pipeline.

## Tracker
https://redhat.atlassian.net/browse/RHOAIENG-74995

## Test plan
- [ ] `/build-konflux` triggers all 8 downstream images
- [ ] `/build-konflux-{name}` triggers only that specific image
- [ ] Existing upstream (opendatahub) pipeline files are untouched