### PR TITLE
Update on-comment triggers for rhoai-2.25 PR pipelines

### DIFF
--- a/.tekton/odh-dashboard-pull-request.yaml
+++ b/.tekton/odh-dashboard-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux$|^/build-konflux-odh-dashboard"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:

--- a/.tekton/odh-mod-arch-model-registry-v2-25-pull-request.yaml
+++ b/.tekton/odh-mod-arch-model-registry-v2-25-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux$|^/build-konflux-model-registry"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:


### PR DESCRIPTION
## Summary
Update both downstream pull-request pipelines on `rhoai-2.25` so a single `/build-konflux` comment triggers all images.

## Comment triggers

| Comment | What triggers |
|---------|--------------|
| `/build-konflux` | Both images (odh-dashboard + model-registry) |
| `/build-konflux-odh-dashboard` | odh-dashboard only |
| `/build-konflux-model-registry` | model-registry only |

## Tracker
https://redhat.atlassian.net/browse/RHOAIENG-74995

## Test plan
- [ ] `/build-konflux` triggers both downstream images
- [ ] `/build-konflux-odh-dashboard` triggers only odh-dashboard
- [ ] `/build-konflux-model-registry` triggers only model-registry