### PR TITLE
Add packages/model-serving/ COPY to Konflux Dockerfiles for upstream PR #8350

### DIFF
--- a/Dockerfile.konflux.agent-ops
+++ b/Dockerfile.konflux.agent-ops
@@ -32,6 +32,7 @@ COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
+COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 

--- a/Dockerfile.konflux.automl
+++ b/Dockerfile.konflux.automl
@@ -32,6 +32,7 @@ COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
+COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 

--- a/Dockerfile.konflux.autorag
+++ b/Dockerfile.konflux.autorag
@@ -32,6 +32,7 @@ COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
+COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 

--- a/Dockerfile.konflux.eval-hub
+++ b/Dockerfile.konflux.eval-hub
@@ -32,6 +32,7 @@ COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
+COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 

--- a/Dockerfile.konflux.genai
+++ b/Dockerfile.konflux.genai
@@ -32,6 +32,7 @@ COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
+COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-72364

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Upstream PR [opendatahub-io/odh-dashboard#8350](https://github.com/opendatahub-io/odh-dashboard/pull/8350) moves 13 model-serving-specific items (types, enums, components, utilities, and a hook) from `@odh-dashboard/internal` (`frontend/src/`) into `@odh-dashboard/model-serving/shared` as subpath exports. That PR updates the upstream `Dockerfile.workspace` files for `agent-ops`, `automl`, `autorag`, `eval-hub`, and `gen-ai` to include `COPY packages/model-serving/`, since the frontend source they already copy now imports from `@odh-dashboard/model-serving/shared` instead of local paths.

This PR mirrors that change in the downstream Konflux Dockerfiles (`Dockerfile.konflux.*`) for the same five modules, ensuring their container builds have the `packages/model-serving/` workspace package available at build time. Without this, the builds would fail when resolving the new cross-package imports.

`Dockerfile.konflux.maas` already included `packages/model-serving/` and required no changes.


## Test Plan
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
 - [ ] Verify Konflux builds pass for affected modules

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
