### PR TITLE
chore: add hardware-profiles package to Konflux Dockerfiles

### DIFF
--- a/Dockerfile.konflux.agent-ops
+++ b/Dockerfile.konflux.agent-ops
@@ -34,6 +34,7 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 

--- a/Dockerfile.konflux.automl
+++ b/Dockerfile.konflux.automl
@@ -34,6 +34,7 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 

--- a/Dockerfile.konflux.autorag
+++ b/Dockerfile.konflux.autorag
@@ -34,6 +34,7 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 

--- a/Dockerfile.konflux.eval-hub
+++ b/Dockerfile.konflux.eval-hub
@@ -34,6 +34,7 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 

--- a/Dockerfile.konflux.genai
+++ b/Dockerfile.konflux.genai
@@ -34,6 +34,7 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 

--- a/Dockerfile.konflux.maas
+++ b/Dockerfile.konflux.maas
@@ -33,6 +33,7 @@ COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
+COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 # Copy packages required for @odh-dashboard/llmd-serving and its dependencies
 COPY --chown=default:root packages/llmd-serving/ ./packages/llmd-serving/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/

--- a/Dockerfile.konflux.mlflow
+++ b/Dockerfile.konflux.mlflow
@@ -33,6 +33,7 @@ COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
+COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 

--- a/Dockerfile.konflux.modelregistry
+++ b/Dockerfile.konflux.modelregistry
@@ -33,6 +33,7 @@ COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
+COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-65095

## Description

Upstream PR opendatahub-io/odh-dashboard#8346 extracts `packages/hardware-profiles/` as a new workspace package. That PR updates the upstream `Dockerfile.workspace` files for all modules that transitively depend on `@odh-dashboard/hardware-profiles` to include `COPY packages/hardware-profiles/`.

This PR mirrors that change in the downstream Konflux Dockerfiles (`Dockerfile.konflux.*`) for the same 8 modules, ensuring their container builds have the `packages/hardware-profiles/` workspace package available at build time.

## Affected files

- `Dockerfile.konflux.agent-ops`
- `Dockerfile.konflux.automl`
- `Dockerfile.konflux.autorag`
- `Dockerfile.konflux.eval-hub`
- `Dockerfile.konflux.genai`
- `Dockerfile.konflux.maas`
- `Dockerfile.konflux.mlflow`
- `Dockerfile.konflux.modelregistry`

## Test plan

- [x] Verify Konflux builds pass for affected modules