### PR TITLE
fix(gen-ai): add protobuf panic suppression to Dockerfile.konflux.genai

### DIFF
--- a/Dockerfile.konflux.genai
+++ b/Dockerfile.konflux.genai
@@ -92,6 +92,12 @@ COPY --from=ui-builder /usr/src/workspace/${UI_SOURCE_CODE}/dist ./static/
 COPY --from=bff-builder /usr/src/app/openapi/ ./openapi/
 USER 65532:65532
 
+# Suppress protobuf duplicate-registration panic caused by mlflow-go's
+# stub trace.proto conflicting with the OTel SDK's real trace.proto.
+# Remove once the mlflow-go proto conflict is resolved (e.g. mlflow-go
+# adopts go.opentelemetry.io/proto/otlp directly).
+ENV GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn
+
 # Expose port 8080
 EXPOSE 8080
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-77605

## Description

The gen-ai BFF binary panics on startup in the Konflux-built image due to a protobuf duplicate-registration conflict. mlflow-go vendors a stub `trace.proto` that conflicts with the OTel SDK's real `trace.proto`, causing Go's protobuf runtime to panic.

The upstream `Dockerfile` and `Dockerfile.workspace` already set `GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn` to suppress this, but `Dockerfile.konflux.genai` was missing it. This adds the same env var to the Konflux Dockerfile.

## How Has This Been Tested?

- Confirmed the upstream `Dockerfile` already carries the identical fix and has been working in dev environments

## Test Impact

No new tests — this is a Dockerfile-only change (single env var addition). The fix is identical to what already exists in the upstream `Dockerfile`. Unit and Cypress tests are not applicable to Dockerfile environment variables.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`