### PR TITLE
fix: set NODE_OPTIONS to prevent webpack OOM on x86_64 builds

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -19,6 +19,7 @@ RUN npm cache clean --force
 RUN npm ci --ignore-scripts
 
 ENV TURBO_TELEMETRY_DISABLED=1
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 # Set Red Hat Openshift AI logo and links
 ENV ODH_LOGO=../images/rhoai-logo.svg


### PR DESCRIPTION
## Summary

- Fix intermittent OOM crash during `npm run build` (webpack/turbo) on x86_64 builds by explicitly setting the V8 heap limit to 4 GiB

## Problem

10% of odh-dashboard-v3-5 builds (3 out of 30) fail with:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

The crash occurs during the webpack/turbo monorepo build on `linux/x86_64` only. The visible symptom is a misleading "no such file or directory" for `frontend/public` — because webpack never finishes generating the output.

Node.js 22 is container-aware and auto-sizes the V8 heap to ~50% of the container's cgroup memory limit. In the Konflux build pod, this default is insufficient for the webpack build under peak allocation.

## Fix

Set `NODE_OPTIONS="--max-old-space-size=4096"` to explicitly allocate 4 GiB for the V8 old-generation heap, overriding the conservative 50% heuristic.

## References

- Node.js docs: https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-mib
- Failed builds: `odh-dashboard-v3-5-on-push-vd5bw`, `odh-dashboard-v3-5-on-push-z7rqd`, `odh-dashboard-v3-5-on-push-kwwcc`

## Test plan

- [ ] Verify next x86_64 build completes without OOM
- [ ] Confirm arm64, ppc64le, s390x builds unaffected
- [ ] Monitor 10+ consecutive builds for regression