### PR TITLE
Fix(RHOAIENG-79253): Add file ownership and permissions to downstream operator Dockerfile

### DIFF
--- a/Dockerfile.konflux.dashboard-operator
+++ b/Dockerfile.konflux.dashboard-operator
@@ -24,7 +24,13 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:2e8edce823a48e51858f1fad
 WORKDIR /
 
 COPY --from=builder /tmp/manager .
-COPY manifests/ /opt/manifests/dashboard/
+COPY --chown=65532:0 manifests/ /opt/manifests/dashboard/
+RUN chmod -R g+w /opt/manifests/dashboard/modules/ \
+    && chmod g+w /opt/manifests/dashboard/odh/params.env \
+    && chmod g+w /opt/manifests/dashboard/odh/standalone/params.env \
+    && chmod g+w /opt/manifests/dashboard/rhoai/params.env \
+    && chmod g+w /opt/manifests/dashboard/rhoai/standalone/params.env \
+    && chmod g+w /opt/manifests/dashboard/sidecar/params.env
 
 USER 65532:65532
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79253

## Description
The downstream `Dockerfile.konflux.dashboard-operator` is missing file ownership and permission settings that exist in the upstream `dashboard-operator/Dockerfile`. This causes `permission denied` errors when the controller (running as non-root user `65532:65532`) attempts to write `params.env` files during reconciliation.

**Changes:**
- Added `--chown=65532:0` to the `COPY manifests/` instruction so files are owned by the runtime user
- Added `chmod g+w` commands for all `params.env` files and the `modules/` directory, matching the upstream Dockerfile

## How Has This Been Tested?
Verified the Dockerfile changes match the upstream `dashboard-operator/Dockerfile` permission model. The upstream Dockerfile has been working correctly with these exact ownership and permission settings.

## Test Impact
No application code changes — Dockerfile-only fix. No unit or Cypress tests applicable.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`