### PR TITLE
Add model-registry/shared COPY to Konflux Dockerfiles for upstream PR #8749

### DIFF
--- a/Dockerfile.konflux.agent-ops
+++ b/Dockerfile.konflux.agent-ops
@@ -34,6 +34,8 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/model-registry/package.json ./packages/model-registry/
+COPY --chown=default:root packages/model-registry/shared/ ./packages/model-registry/shared/
 COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 COPY --chown=default:root packages/connection-types/ ./packages/connection-types/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/Dockerfile.konflux.automl
+++ b/Dockerfile.konflux.automl
@@ -34,6 +34,8 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/model-registry/package.json ./packages/model-registry/
+COPY --chown=default:root packages/model-registry/shared/ ./packages/model-registry/shared/
 COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 COPY --chown=default:root packages/connection-types/ ./packages/connection-types/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/Dockerfile.konflux.autorag
+++ b/Dockerfile.konflux.autorag
@@ -34,6 +34,8 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/model-registry/package.json ./packages/model-registry/
+COPY --chown=default:root packages/model-registry/shared/ ./packages/model-registry/shared/
 COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 COPY --chown=default:root packages/connection-types/ ./packages/connection-types/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/Dockerfile.konflux.eval-hub
+++ b/Dockerfile.konflux.eval-hub
@@ -34,6 +34,8 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/model-registry/package.json ./packages/model-registry/
+COPY --chown=default:root packages/model-registry/shared/ ./packages/model-registry/shared/
 COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 COPY --chown=default:root packages/connection-types/ ./packages/connection-types/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/Dockerfile.konflux.genai
+++ b/Dockerfile.konflux.genai
@@ -34,6 +34,8 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/model-registry/package.json ./packages/model-registry/
+COPY --chown=default:root packages/model-registry/shared/ ./packages/model-registry/shared/
 COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/
 COPY --chown=default:root packages/connection-types/ ./packages/connection-types/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/Dockerfile.konflux.modelregistry
+++ b/Dockerfile.konflux.modelregistry
@@ -39,6 +39,8 @@ COPY --chown=default:root packages/connection-types/ ./packages/connection-types
 COPY --chown=default:root frontend/src/ ./frontend/src/
 
 # Copy the specific module source code
+COPY --chown=default:root packages/${MODULE_NAME}/package.json ./packages/${MODULE_NAME}/
+COPY --chown=default:root packages/${MODULE_NAME}/shared/ ./packages/${MODULE_NAME}/shared/
 COPY --chown=default:root ${UI_SOURCE_CODE} ./${UI_SOURCE_CODE}
 
 # Change file ownership to the assemble user


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-65106

## Description

Upstream PR opendatahub-io/odh-dashboard#8749 consolidates shared types (`DeployPrefillData`, `ModelDeployPrefillInfo`, `RegisteredModelRef`) into `@odh-dashboard/model-registry/shared` as a subpath export. That PR updates the upstream `Dockerfile.workspace` files for `agent-ops`, `automl`, `autorag`, `eval-hub`, `gen-ai`, and `model-registry` to include `packages/model-registry/package.json` and `packages/model-registry/shared/`, since `model-serving` now imports types from `@odh-dashboard/model-registry/shared`.

This PR mirrors that change in the downstream Konflux Dockerfiles (`Dockerfile.konflux.*`) for the same modules, ensuring their container builds have the model-registry shared types available at build time. Without this, the builds would fail when resolving the new cross-package type imports.

`Dockerfile.konflux.maas` already included the full `packages/model-registry/` and required no changes.

## Test Plan

- Verify Konflux builds pass for affected modules

## Request review criteria:

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The code follows our Best Practices
- [x] The developer has added tests or explained why testing cannot be added

/hold opendatahub-io/odh-dashboard#8749 must merge and sync downstream first.

Made with [Cursor](https://cursor.com)