### PR TITLE
fix(cve): update npm dependencies for 9 CVE fixes (#8438)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,7 +80,7 @@
     "@patternfly/react-virtualized-extension": "^6.1.0",
     "@segment/analytics-next": "^1.72.0",
     "@types/classnames": "^2.3.1",
-    "axios": "^1.15.0",
+    "axios": "^1.18.1",
     "classnames": "^2.2.6",
     "compare-versions": "^3.6.0",
     "dompurify": "^3.2.4",
@@ -96,8 +96,8 @@
     "react-dropzone": "^14.2.3",
     "react-markdown": "^10.1.0",
     "react-redux": "^8.0.4",
-    "react-router": "^7.6.2",
-    "react-router-dom": "^7.6.2",
+    "react-router": "^7.15.1",
+    "react-router-dom": "^7.15.1",
     "redux": "^4.2.0",
     "redux-thunk": "^2.4.1",
     "rehype-raw": "^7.0.0",
@@ -226,8 +226,8 @@
   "overrides": {
     "@openshift/dynamic-plugin-sdk-utils": {
       "react-redux": "^8.0.4",
-      "react-router": "^7.6.2",
-      "react-router-dom": "^7.6.2",
+      "react-router": "^7.15.1",
+      "react-router-dom": "^7.15.1",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",
       "@patternfly/react-core": "^6.3.1",
@@ -239,7 +239,7 @@
     "@patternfly/react-topology": {
       "react": "^18.2.0"
     },
-    "react-router": "^7.6.2",
+    "react-router": "^7.15.1",
     "ws": "^8.17.1",
     "dompurify": "^3.2.4",
     "redux": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/tar": "^6.1.13",
         "jsonpath-plus": "^10.3.0",
         "tough-cookie": "^4.1.3",
-        "ws": "^8.17.1"
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "dotenv": "^16.4.7",
@@ -206,7 +206,7 @@
         "@patternfly/react-virtualized-extension": "^6.1.0",
         "@segment/analytics-next": "^1.72.0",
         "@types/classnames": "^2.3.1",
-        "axios": "^1.15.0",
+        "axios": "^1.18.1",
         "classnames": "^2.2.6",
         "compare-versions": "^3.6.0",
         "dompurify": "^3.2.4",
@@ -222,8 +222,8 @@
         "react-dropzone": "^14.2.3",
         "react-markdown": "^10.1.0",
         "react-redux": "^8.0.4",
-        "react-router": "^7.6.2",
-        "react-router-dom": "^7.6.2",
+        "react-router": "^7.15.1",
+        "react-router-dom": "^7.15.1",
         "redux": "^4.2.0",
         "redux-thunk": "^2.4.1",
         "rehype-raw": "^7.0.0",
@@ -396,6 +396,18 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "frontend/node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "frontend/node_modules/protobufjs": {
@@ -2660,23 +2672,6 @@
         "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@cypress/request/node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
       },
       "engines": {
         "node": ">= 6"
@@ -7881,22 +7876,6 @@
         "form-data": "^4.0.4"
       }
     },
-    "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@types/node-forge": {
       "version": "1.3.14",
       "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
@@ -8365,9 +8344,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9697,28 +9676,13 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
       "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -10308,9 +10272,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -14963,9 +14927,9 @@
       }
     },
     "node_modules/eslint-plugin-no-barrel-files/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15954,9 +15918,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -16860,20 +16824,19 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.35",
-        "safe-buffer": "^5.2.1"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/form-data-encoder": {
@@ -17267,9 +17230,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -17692,9 +17655,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -21268,9 +21231,9 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -21394,23 +21357,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/jsep": {
@@ -24007,9 +23953,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -27754,9 +27700,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -27776,12 +27722,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
-      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.8.2"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -28317,20 +28263,6 @@
       "optional": true,
       "dependencies": {
         "throttleit": "^1.0.0"
-      }
-    },
-    "node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/request/node_modules/http-signature": {
@@ -29416,9 +29348,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -30098,13 +30030,6 @@
         "semver": "bin/semver"
       }
     },
-    "node_modules/slnodejs/node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/slnodejs/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -30164,9 +30089,9 @@
       }
     },
     "node_modules/soft-assert/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -34572,9 +34497,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/tar": "^6.1.13",
     "jsonpath-plus": "^10.3.0",
     "tough-cookie": "^4.1.3",
-    "ws": "^8.17.1"
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "dotenv": "^16.4.7",
@@ -92,8 +92,8 @@
   "overrides": {
     "@openshift/dynamic-plugin-sdk-utils": {
       "react-redux": "^8.0.4",
-      "react-router": "^7.6.2",
-      "react-router-dom": "^7.6.2",
+      "react-router": "^7.15.1",
+      "react-router-dom": "^7.15.1",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",
       "@patternfly/react-core": "^6.3.1",
@@ -106,8 +106,8 @@
     "@patternfly/react-topology": {
       "react": "^18.2.0"
     },
-    "react-router": "^7.6.2",
-    "ws": "^8.17.1",
+    "react-router": "^7.15.1",
+    "ws": "^8.21.0",
     "dompurify": "^3.4.0",
     "@types/tar": "^6.1.13",
     "jsonpath-plus": "^10.3.0",
@@ -115,10 +115,13 @@
     "redux": "^4.2.0",
     "qs": "^6.14.1",
     "tar": ">=7.5.3",
-    "axios": "^1.15.1",
+    "axios": ">=1.18.1",
     "svgo": "2.8.2",
     "lodash": "^4.18.0",
     "lodash-es": "^4.18.0",
-    "fast-uri": ">=3.1.1"
+    "fast-uri": "3.1.4",
+    "form-data": ">=4.0.6",
+    "shell-quote": ">=1.8.4",
+    "js-cookie": ">=3.0.6"
   }
 }


### PR DESCRIPTION
* fix(cve): update axios to >=1.18.1

Fixes CVE-2026-42044, CVE-2026-42264, CVE-2026-44486, CVE-2026-44487, CVE-2026-44488, CVE-2026-44492, CVE-2026-44494, CVE-2026-44495, CVE-2026-44496

Update axios override in root package.json to >=1.18.1 and bump frontend direct dependency from ^1.15.0 to ^1.18.1. Minor version bump only, no breaking changes.

* fix(cve): update fast-uri to 3.1.3

Fixes CVE-2026-13676, CVE-2026-6322

Update fast-uri override from >=3.1.1 to 3.1.3. Patch version bump, no breaking changes.

* fix(cve): update ws to ^8.21.0

Fixes CVE-2026-45736, CVE-2026-48779

Update ws dependency and override from ^8.17.1 to ^8.21.0. Minor version bump within 8.x, no breaking changes.

* fix(cve): update react-router and react-router-dom to ^7.15.1

Fixes CVE-2026-42211, CVE-2026-42342

Update react-router and react-router-dom from ^7.6.2 to ^7.15.1 (resolves to 7.18.1). Updated in root overrides, sdk-utils nested overrides, and frontend direct deps. Minor version bump within 7.x.

* fix(cve): update form-data to >=4.0.6

Fixes CVE-2026-12143

Add form-data override to >=4.0.6, consolidating all instances from 4.0.4/4.0.5/2.5.5 to 4.0.6. Patch version bump, no breaking changes.

* fix(cve): update brace-expansion to 2.0.3

Fixes CVE-2026-13149

Add brace-expansion override pinned to 2.0.3. Patch bump from 2.0.2, no breaking changes.

* fix(cve): update shell-quote to >=1.8.4

Fixes CVE-2026-13311

Add shell-quote override >=1.8.4 (resolves to 1.9.0). Minor version bump within 1.x, no breaking changes.

* fix(cve): update js-cookie to >=3.0.6

Fixes CVE-2026-46625

Add js-cookie override >=3.0.6 (resolves to 3.0.8). Patch version bump within 3.0.x, no breaking changes.

* fix(cve): bump fast-uri from 3.1.3 to 3.1.4

Addresses GHSA-v2hh-gcrm-f6hx which flagged fast-uri 3.1.3 as still vulnerable. Patch bump, no breaking changes.

* fix(cve): remove brace-expansion override (breaks nyc coverage)

The global brace-expansion override to 2.0.3 broke nyc/istanbul coverage reporting (brace_expansion_1.expand is not a function). Additionally, npm audit now flags <=5.0.7 meaning no safe version exists yet. Without the override, npm naturally resolves to 1.1.16 (root) and 2.1.2 (nested) — the latest available patches.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
