### PR TITLE
fix(autox): cherry-pick AutoML/AutoRAG visualization and pipeline fixes to rhoai-3.5

### DIFF
--- a/packages/automl/frontend/src/app/components/run-results/AutomlPipelineVisualization.scss
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlPipelineVisualization.scss
@@ -10,14 +10,6 @@
   border-bottom: 1px solid var(--pf-t--global--border--color--default);
 }
 
-.automl-pipeline-visualization__toolbar {
-  margin-left: auto;
-
-  .pf-v6-l-flex {
-    justify-content: flex-end;
-  }
-}
-
 .automl-pipeline-visualization__body {
   height: 45vh;
   min-height: 45vh;
@@ -54,16 +46,4 @@
   height: 100%;
   min-height: 0;
   overflow: hidden;
-}
-
-@media (max-width: 992px) {
-  .automl-pipeline-visualization__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .automl-pipeline-visualization__toolbar {
-    margin-left: 0;
-    width: 100%;
-  }
 }

--- a/packages/automl/frontend/src/app/components/run-results/AutomlPipelineVisualization.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlPipelineVisualization.tsx
@@ -102,14 +102,9 @@ const AutomlPipelineVisualization: React.FC<AutomlPipelineVisualizationProps> = 
         className="automl-pipeline-visualization__header"
         alignItems={{ default: 'alignItemsCenter' }}
         justifyContent={{ default: 'justifyContentSpaceBetween' }}
-        flexWrap={{ default: 'wrap' }}
-        spaceItems={{ default: 'spaceItemsMd' }}
       >
         <FlexItem>
-          <Flex
-            alignItems={{ default: 'alignItemsCenter' }}
-            spaceItems={{ default: 'spaceItemsMd' }}
-          >
+          <Flex>
             <FlexItem>
               <Title headingLevel="h3" size="lg">
                 {runTitle}
@@ -127,13 +122,8 @@ const AutomlPipelineVisualization: React.FC<AutomlPipelineVisualizationProps> = 
           </Flex>
         </FlexItem>
 
-        <FlexItem className="automl-pipeline-visualization__toolbar">
-          <Flex
-            alignItems={{ default: 'alignItemsCenter' }}
-            justifyContent={{ default: 'justifyContentFlexEnd' }}
-            spaceItems={{ default: 'spaceItemsMd' }}
-            flexWrap={{ default: 'wrap' }}
-          >
+        <FlexItem>
+          <Flex>
             <FlexItem>
               <Button
                 variant="tertiary"

--- a/packages/automl/frontend/src/app/components/run-results/StepDetailsPanel.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/StepDetailsPanel.tsx
@@ -10,7 +10,10 @@ import {
   DrawerCloseButton,
   DrawerHead,
   DrawerPanelBody,
+  Flex,
+  FlexItem,
   Label,
+  Popover,
   Spinner,
   type SpinnerProps,
   Stack,
@@ -18,14 +21,15 @@ import {
   Title,
   type TitleProps,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { DashboardPopupIconButton } from 'mod-arch-shared';
 import React from 'react';
 import { useAutomlResultsContext } from '~/app/context/AutomlResultsContext';
 import type { ComponentStageMap } from '~/app/hooks/useComponentStageMap';
 import type { PipelineRun } from '~/app/types';
-import { getSelectedModels } from '~/app/topology/stageMapStatus';
+import { getSelectedModels, BRANCHING_STAGE_ID } from '~/app/topology/stageMapStatus';
 import type { PipelineStatusFilter } from '~/app/topology/tree-view/types';
-import { getStepMetadata } from '~/app/topology/tree-view/stepMetadata';
+import { getStepMetadata, type StepDetail } from '~/app/topology/tree-view/stepMetadata';
 import {
   parseStageMapNodeId,
   type ParsedStageMapNode,
@@ -79,6 +83,38 @@ const resolveBranchModelKey = (
     return undefined;
   }
   return resolveBestModelKey(models, branchModels[parsedNodeId.branchIndex]);
+};
+
+type StepDetailTermProps = {
+  detail: StepDetail;
+};
+
+const StepDetailTerm: React.FC<StepDetailTermProps> = ({ detail }) => {
+  if (!detail.help) {
+    return <DescriptionListTerm>{detail.label}</DescriptionListTerm>;
+  }
+
+  return (
+    <DescriptionListTerm>
+      <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapXs' }}>
+        <FlexItem>{detail.label}</FlexItem>
+        <FlexItem>
+          <Popover
+            aria-label={`${detail.help.header} help`}
+            headerContent={detail.help.header}
+            bodyContent={detail.help.body}
+          >
+            <DashboardPopupIconButton
+              aria-label={`More info for ${detail.label.toLowerCase()}`}
+              icon={<OutlinedQuestionCircleIcon />}
+              hasNoPadding
+              data-testid={`step-detail-help-${detail.label.toLowerCase().replace(/\s+/g, '-')}`}
+            />
+          </Popover>
+        </FlexItem>
+      </Flex>
+    </DescriptionListTerm>
+  );
 };
 
 type StepDetailsPanelHeaderProps = {
@@ -194,23 +230,16 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
                 </Content>
               </StackItem>
               {showPipelineSummary && (
-                <>
-                  <StackItem>
-                    <Title headingLevel="h4" size="md">
-                      Details
-                    </Title>
-                  </StackItem>
-                  <StackItem>
-                    <DescriptionList isCompact data-testid="pipeline-summary-details">
-                      {pipelineSummaryDetails.map((detail, index) => (
-                        <DescriptionListGroup key={`${detail.label}-${index}`}>
-                          <DescriptionListTerm>{detail.label}:</DescriptionListTerm>
-                          <DescriptionListDescription>{detail.value}</DescriptionListDescription>
-                        </DescriptionListGroup>
-                      ))}
-                    </DescriptionList>
-                  </StackItem>
-                </>
+                <StackItem>
+                  <DescriptionList isCompact data-testid="pipeline-summary-details">
+                    {pipelineSummaryDetails.map((detail, index) => (
+                      <DescriptionListGroup key={`${detail.label}-${index}`}>
+                        <StepDetailTerm detail={detail} />
+                        <DescriptionListDescription>{detail.value}</DescriptionListDescription>
+                      </DescriptionListGroup>
+                    ))}
+                  </DescriptionList>
+                </StackItem>
               )}
             </Stack>
           )}
@@ -240,6 +269,8 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
   const statusLabel = getStepStateLabel(nodeData.stepState);
   const inProgressLoadingContent = getStepDetailsLoadingContent();
   const isStepLoading = nodeData.stepState === 'active';
+  const isBranchingStage =
+    parsedNodeId?.type === 'stage' && parsedNodeId.stageId === BRANCHING_STAGE_ID;
 
   return (
     <>
@@ -254,8 +285,10 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
                 customIcon={<ExclamationCircleIcon />}
                 data-testid="step-failed-alert"
               >
-                The pipeline stopped during {panelTitle}. Branch steps are reported as a single
-                group — remaining steps were not run.
+                The pipeline stopped during {panelTitle}.
+                {isBranchingStage
+                  ? ' Branch steps are reported as a single group — remaining steps were not run.'
+                  : null}
               </Alert>
             </StackItem>
           )}
@@ -276,24 +309,16 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
               />
             </StackItem>
           ) : (
-            <>
-              <StackItem>
-                <Title headingLevel="h4" size="md">
-                  Details
-                </Title>
-              </StackItem>
-
-              <StackItem>
-                <DescriptionList isCompact>
-                  {metadata.details.map((detail, index) => (
-                    <DescriptionListGroup key={`${detail.label}-${index}`}>
-                      <DescriptionListTerm>{detail.label}:</DescriptionListTerm>
-                      <DescriptionListDescription>{detail.value}</DescriptionListDescription>
-                    </DescriptionListGroup>
-                  ))}
-                </DescriptionList>
-              </StackItem>
-            </>
+            <StackItem>
+              <DescriptionList isCompact>
+                {metadata.details.map((detail, index) => (
+                  <DescriptionListGroup key={`${detail.label}-${index}`}>
+                    <StepDetailTerm detail={detail} />
+                    <DescriptionListDescription>{detail.value}</DescriptionListDescription>
+                  </DescriptionListGroup>
+                ))}
+              </DescriptionList>
+            </StackItem>
           )}
         </Stack>
       </DrawerPanelBody>

--- a/packages/automl/frontend/src/app/components/run-results/StepDetailsPanel.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/StepDetailsPanel.tsx
@@ -12,9 +12,11 @@ import {
   DrawerPanelBody,
   Label,
   Spinner,
+  type SpinnerProps,
   Stack,
   StackItem,
   Title,
+  type TitleProps,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
@@ -35,6 +37,7 @@ import {
   getPipelineStatusFilterLabel,
   getPipelineStatusLabelProps,
   getPipelineTreeLoadingContent,
+  getStepDetailsLoadingContent,
   getStepStateLabel,
   type PipelineStatusLabel,
   type PipelineTreeLoadingMode,
@@ -119,16 +122,20 @@ const StepDetailsPanelHeader: React.FC<StepDetailsPanelHeaderProps> = ({
 type StepDetailsLoadingBodyProps = {
   primaryText: string;
   secondaryText: string;
+  spinnerSize?: SpinnerProps['size'];
+  titleSize?: TitleProps['size'];
 };
 
 const StepDetailsLoadingBody: React.FC<StepDetailsLoadingBodyProps> = ({
   primaryText,
   secondaryText,
+  spinnerSize = 'xl',
+  titleSize = 'xl',
 }) => (
   <div className="automl-step-details__empty-state">
     <div className="automl-step-details__empty-state-content">
-      <Spinner size="xl" className="automl-step-details__empty-state-spinner" />
-      <Title headingLevel="h3" size="xl" className="automl-step-details__empty-state-title">
+      <Spinner size={spinnerSize} className="automl-step-details__empty-state-spinner" />
+      <Title headingLevel="h3" size={titleSize} className="automl-step-details__empty-state-title">
         {primaryText}
       </Title>
       <Content component={ContentVariants.p} className="automl-step-details__empty-state-subtitle">
@@ -231,7 +238,7 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
     nodeData.stepState === 'completed';
   const panelTitle = isBestModel ? 'Best model' : (nodeData.label ?? 'Step details');
   const statusLabel = getStepStateLabel(nodeData.stepState);
-  const inProgressLoadingContent = getPipelineDetailsEmptyContent('in-progress');
+  const inProgressLoadingContent = getStepDetailsLoadingContent();
   const isStepLoading = nodeData.stepState === 'active';
 
   return (
@@ -264,6 +271,8 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
               <StepDetailsLoadingBody
                 primaryText={inProgressLoadingContent.primaryText ?? inProgressLoadingContent.title}
                 secondaryText={inProgressLoadingContent.secondaryText ?? ''}
+                spinnerSize="lg"
+                titleSize="lg"
               />
             </StackItem>
           ) : (

--- a/packages/automl/frontend/src/app/components/run-results/__tests__/pipelineStatusLabels.spec.ts
+++ b/packages/automl/frontend/src/app/components/run-results/__tests__/pipelineStatusLabels.spec.ts
@@ -88,7 +88,7 @@ describe('pipeline status label fallbacks', () => {
     expect(getPipelineDetailsEmptyContent(unknownStatus)).toEqual({
       title: 'Pipeline details',
       variant: 'idle',
-      secondaryText: 'Click on any node in the pipeline to view its details here.',
+      secondaryText: 'Select a step to view its details.',
     });
   });
 });

--- a/packages/automl/frontend/src/app/components/run-results/__tests__/pipelineSummaryMetadata.spec.ts
+++ b/packages/automl/frontend/src/app/components/run-results/__tests__/pipelineSummaryMetadata.spec.ts
@@ -80,7 +80,14 @@ describe('getPipelineSummaryDetails', () => {
     expect(details).toEqual([
       { label: 'Total run time', value: '2 m 55 s' },
       { label: 'Models evaluated', value: '3' },
-      { label: 'Winning model', value: 'LightGBM_BAG_L2' },
+      {
+        label: 'Winning model',
+        value: 'LightGBM_BAG_L2',
+        help: {
+          header: 'Winning model',
+          body: 'The model that achieved the highest evaluation score during training.',
+        },
+      },
       { label: 'Evaluation metric', value: 'Accuracy' },
     ]);
   });
@@ -167,7 +174,14 @@ describe('getPipelineSummaryDetails', () => {
     expect(details).toEqual([
       { label: 'Total run time', value: '—' },
       { label: 'Models evaluated', value: '—' },
-      { label: 'Winning model', value: '—' },
+      {
+        label: 'Winning model',
+        value: '—',
+        help: {
+          header: 'Winning model',
+          body: 'The model that achieved the highest evaluation score during training.',
+        },
+      },
       { label: 'Evaluation metric', value: '—' },
     ]);
   });

--- a/packages/automl/frontend/src/app/components/run-results/pipelineStatusLabels.ts
+++ b/packages/automl/frontend/src/app/components/run-results/pipelineStatusLabels.ts
@@ -152,6 +152,13 @@ export type PipelineDetailsEmptyContent = {
   secondaryText?: string;
 };
 
+export const getStepDetailsLoadingContent = (): PipelineDetailsEmptyContent => ({
+  title: 'Running task',
+  variant: 'loading',
+  primaryText: 'Running task',
+  secondaryText: 'Details will appear once this step is complete.',
+});
+
 export const getPipelineDetailsEmptyContent = (
   statusFilter: PipelineStatusFilter,
 ): PipelineDetailsEmptyContent => {

--- a/packages/automl/frontend/src/app/components/run-results/pipelineStatusLabels.ts
+++ b/packages/automl/frontend/src/app/components/run-results/pipelineStatusLabels.ts
@@ -44,9 +44,9 @@ export const getPipelineTreeLoadingContent = (
   switch (mode) {
     case 'preparing':
       return {
-        title: 'Preparing pipeline',
-        primaryText: 'Starting your evaluation, this may take a few moments',
-        secondaryText: 'The pipeline visualization will appear when the run structure is ready.',
+        title: 'Starting evaluation',
+        primaryText: 'Starting evaluation',
+        secondaryText: 'This might take a few moments.',
       };
     case 'hydrating':
     default:
@@ -165,17 +165,17 @@ export const getPipelineDetailsEmptyContent = (
   switch (statusFilter) {
     case 'loading':
       return {
-        title: 'Preparing pipeline',
+        title: 'Starting evaluation',
         variant: 'loading',
-        primaryText: 'Preparing pipeline',
-        secondaryText: 'Pipeline steps will appear on the left once the run structure is ready.',
+        primaryText: 'Starting evaluation',
+        secondaryText: 'This might take a few moments.',
       };
     case 'in-progress':
       return {
         title: 'Running pipeline',
         variant: 'loading',
-        primaryText: 'Running pipeline',
-        secondaryText: 'Details will appear once the step is complete.',
+        primaryText: 'Pipeline run in progress',
+        secondaryText: 'Step details will become available as steps complete.',
       };
     case 'completed':
     case 'canceled':
@@ -184,7 +184,7 @@ export const getPipelineDetailsEmptyContent = (
       return {
         title: 'Pipeline details',
         variant: 'idle',
-        secondaryText: 'Click on any node in the pipeline to view its details here.',
+        secondaryText: 'Select a step to view its details.',
       };
   }
 };

--- a/packages/automl/frontend/src/app/components/run-results/pipelineSummaryMetadata.ts
+++ b/packages/automl/frontend/src/app/components/run-results/pipelineSummaryMetadata.ts
@@ -150,6 +150,10 @@ export function getPipelineSummaryDetails(
     {
       label: 'Winning model',
       value: resolveWinningModelDisplay(models, componentStageMap, parameters) ?? '—',
+      help: {
+        header: 'Winning model',
+        body: 'The model that achieved the highest evaluation score during training.',
+      },
     },
     {
       label: 'Evaluation metric',

--- a/packages/automl/frontend/src/app/topology/__tests__/buildStageMapTopology.spec.ts
+++ b/packages/automl/frontend/src/app/topology/__tests__/buildStageMapTopology.spec.ts
@@ -191,7 +191,7 @@ describe('buildStageMapTopology', () => {
       const nodes = buildStageMapTopology(stageMap);
 
       const refitNode = nodes.find((n) => n.id === 'training__refit_full');
-      expect(refitNode?.label).toBe('Refit models');
+      expect(refitNode?.label).toBe('Refit and evaluate');
 
       const evalNode = nodes.find((n) => n.id === 'training__evaluate_models');
       expect(evalNode?.label).toBe('Evaluate models');
@@ -248,9 +248,9 @@ describe('buildStageMapTopology', () => {
       const step2 = nodes.find((n) => n.id === 'training__step__model_training__branch-0');
       const step3 = nodes.find((n) => n.id === 'training__step__stacking__branch-0');
 
-      expect(step1?.label).toBe('Feature engineering');
-      expect(step2?.label).toBe('Model training');
-      expect(step3?.label).toBe('Stacking');
+      expect(step1?.label).toBe('Engineer features');
+      expect(step2?.label).toBe('Train model');
+      expect(step3?.label).toBe('Stack predictions');
     });
 
     it('should cap branch step expansion to MAX_MODEL_SELECTION_STEPS', () => {

--- a/packages/automl/frontend/src/app/topology/__tests__/parseUtils.spec.ts
+++ b/packages/automl/frontend/src/app/topology/__tests__/parseUtils.spec.ts
@@ -95,14 +95,14 @@ describe('parseRuntimeInfoFromRunDetails', () => {
     expect(result?.state).toBe(RuntimeStateKF.FAILED);
   });
 
-  it('should pick worst status when main and driver tasks both exist', () => {
+  it('should prefer the executor status over the driver when both exist', () => {
     const details = makeRunDetails(
       { task_id: 'task-1', display_name: 'task-1', state: RuntimeStateKF.SUCCEEDED },
       { task_id: 'task-1-driver', display_name: 'task-1-driver', state: RuntimeStateKF.FAILED },
     );
     const result = parseRuntimeInfoFromRunDetails('task-1', details);
 
-    expect(result?.state).toBe(RuntimeStateKF.FAILED);
+    expect(result?.state).toBe(RuntimeStateKF.SUCCEEDED);
   });
 
   it('should keep succeeded when paired with canceled driver status', () => {
@@ -115,14 +115,14 @@ describe('parseRuntimeInfoFromRunDetails', () => {
     expect(result?.state).toBe(RuntimeStateKF.SUCCEEDED);
   });
 
-  it('should pick failed over canceled', () => {
+  it('should prefer the executor status over the driver even when the driver failed', () => {
     const details = makeRunDetails(
       { task_id: 'task-1', display_name: 'task-1', state: RuntimeStateKF.CANCELED },
       { task_id: 'task-1-driver', display_name: 'task-1-driver', state: RuntimeStateKF.FAILED },
     );
     const result = parseRuntimeInfoFromRunDetails('task-1', details);
 
-    expect(result?.state).toBe(RuntimeStateKF.FAILED);
+    expect(result?.state).toBe(RuntimeStateKF.CANCELED);
   });
 });
 

--- a/packages/automl/frontend/src/app/topology/__tests__/stageMapLabels.spec.ts
+++ b/packages/automl/frontend/src/app/topology/__tests__/stageMapLabels.spec.ts
@@ -2,7 +2,10 @@ import { resolveStageLabel, resolveStepLabel } from '~/app/topology/stageMapLabe
 
 describe('resolveStageLabel', () => {
   it('returns mapped display names for known stage IDs', () => {
-    expect(resolveStageLabel('model_selection')).toBe('Model selection');
+    expect(resolveStageLabel('model_selection')).toBe('Select models');
+    expect(resolveStageLabel('split_and_export')).toBe('Split data');
+    expect(resolveStageLabel('prepare_data')).toBe('Prepare data');
+    expect(resolveStageLabel('refit_full')).toBe('Refit and evaluate');
     expect(resolveStageLabel('build_leaderboard')).toBe('Build leaderboard');
   });
 
@@ -18,8 +21,11 @@ describe('resolveStageLabel', () => {
 
 describe('resolveStepLabel', () => {
   it('returns mapped display names for known step IDs', () => {
-    expect(resolveStepLabel('feature_engineering')).toBe('Feature engineering');
-    expect(resolveStepLabel('model_training')).toBe('Model training');
+    expect(resolveStepLabel('feature_engineering')).toBe('Engineer features');
+    expect(resolveStepLabel('model_training')).toBe('Train model');
+    expect(resolveStepLabel('stacking')).toBe('Stack predictions');
+    expect(resolveStepLabel('model_evaluation')).toBe('Evaluate results');
+    expect(resolveStepLabel('evaluation')).toBe('Evaluate results');
   });
 
   it('falls back for unknown step IDs', () => {

--- a/packages/automl/frontend/src/app/topology/__tests__/useAutomlTaskTopology.spec.ts
+++ b/packages/automl/frontend/src/app/topology/__tests__/useAutomlTaskTopology.spec.ts
@@ -373,7 +373,7 @@ describe('useAutomlTaskTopology', () => {
     expect(nodes[2].data?.runStatus).toBeUndefined();
   });
 
-  it('should map title-cased API display name to Model selection via normalized lookup', () => {
+  it('should map title-cased API display name to Select models via normalized lookup', () => {
     const spec: PipelineSpecVariable = {
       root: {
         dag: {
@@ -393,10 +393,10 @@ describe('useAutomlTaskTopology', () => {
       },
     };
     const renderResult = testHook(useAutomlTaskTopology)(spec, undefined);
-    expect(renderResult.result.current[1].label).toBe('Model selection');
+    expect(renderResult.result.current[1].label).toBe('Select models');
   });
 
-  it('should map autogluon-timeseries-models-selection task id to Model selection label', () => {
+  it('should map autogluon-timeseries-models-selection task id to Select models label', () => {
     const spec: PipelineSpecVariable = {
       root: {
         dag: {
@@ -418,7 +418,7 @@ describe('useAutomlTaskTopology', () => {
     const renderResult = testHook(useAutomlTaskTopology)(spec, undefined);
     const nodes = renderResult.result.current;
 
-    expect(nodes[1].label).toBe('Model selection');
+    expect(nodes[1].label).toBe('Select models');
   });
 
   it('should ignore inherited prototype names listed as dependentTasks', () => {

--- a/packages/automl/frontend/src/app/topology/parseUtils.ts
+++ b/packages/automl/frontend/src/app/topology/parseUtils.ts
@@ -40,7 +40,11 @@ const worstStatus = (details: TaskDetailKF[]): TaskDetailKF['state'] =>
 
 /**
  * Get the run status of a task from the RunDetailsKF (task_details array).
- * Considers both the main task and its driver task, picking the most-progressed status.
+ * The `-driver` task only resolves inputs/caching and can finish independently of the
+ * actual executor container — e.g. it may report SUCCEEDED before the executor even starts,
+ * or CANCELED as cleanup after the executor has already finished. Its state must never
+ * override the executor's real state, so the executor entry (if present) is authoritative;
+ * the driver entry is only used as a fallback before the executor appears in task_details.
  */
 export const parseRuntimeInfoFromRunDetails = (
   taskId: string,
@@ -50,7 +54,11 @@ export const parseRuntimeInfoFromRunDetails = (
     return undefined;
   }
 
-  const nameVariants = [taskId, `${taskId}-driver`];
+  const driverName = `${taskId}-driver`;
+  const isDriverEntry = (td: TaskDetailKF): boolean =>
+    td.display_name === driverName || td.task_id === driverName;
+
+  const nameVariants = [taskId, driverName];
   const matchingDetails = runDetails.task_details.filter(
     (td) =>
       (td.display_name != null && nameVariants.includes(td.display_name)) ||
@@ -61,11 +69,14 @@ export const parseRuntimeInfoFromRunDetails = (
     return undefined;
   }
 
+  const executorDetails = matchingDetails.filter((td) => !isDriverEntry(td));
+  const relevantDetails = executorDetails.length > 0 ? executorDetails : matchingDetails;
+
   return {
-    startTime: matchingDetails[0].start_time,
-    completeTime: matchingDetails[0].end_time,
-    state: worstStatus(matchingDetails),
-    taskId: matchingDetails[0].task_id,
+    startTime: relevantDetails[0].start_time,
+    completeTime: relevantDetails[0].end_time,
+    state: worstStatus(relevantDetails),
+    taskId: relevantDetails[0].task_id,
   };
 };
 

--- a/packages/automl/frontend/src/app/topology/stageMapLabels.ts
+++ b/packages/automl/frontend/src/app/topology/stageMapLabels.ts
@@ -5,19 +5,22 @@ export const STAGE_DISPLAY_NAMES: Record<string, string> = {
   read_and_sample: 'Read and sample data',
   cleanse: 'Cleanse data',
   split: 'Split data',
+  split_and_export: 'Split data',
   write_outputs: 'Write outputs',
+  prepare_data: 'Prepare data',
   load_data: 'Load data',
-  model_selection: 'Model selection',
-  refit_full: 'Refit models',
+  model_selection: 'Select models',
+  refit_full: 'Refit and evaluate',
   evaluate_models: 'Evaluate models',
   build_leaderboard: 'Build leaderboard',
 };
 
 export const STEP_DISPLAY_NAMES: Record<string, string> = {
-  feature_engineering: 'Feature engineering',
-  model_training: 'Model training',
-  stacking: 'Stacking',
-  model_evaluation: 'Model evaluation',
+  feature_engineering: 'Engineer features',
+  model_training: 'Train model',
+  stacking: 'Stack predictions',
+  model_evaluation: 'Evaluate results',
+  evaluation: 'Evaluate results',
 };
 
 const fallbackStageLabel = (stageId: string): string => {

--- a/packages/automl/frontend/src/app/topology/tree-view/__tests__/stepMetadata.spec.ts
+++ b/packages/automl/frontend/src/app/topology/tree-view/__tests__/stepMetadata.spec.ts
@@ -135,7 +135,9 @@ describe('getStepMetadata', () => {
       componentStageMap,
     });
 
-    expect(metadata.description).toBe('Validating inputs from the stage map.');
+    expect(metadata.description).toBe(
+      'Validating pipeline inputs and configuration before processing begins.',
+    );
     expect(metadata.details[0]).toEqual({ label: 'Duration', value: '4 m 50 s' });
   });
 
@@ -181,7 +183,7 @@ describe('getStepMetadata', () => {
       componentStageMap,
     });
 
-    expect(metadata.description).toBe('Prepare data from the stage map.');
+    expect(metadata.description).toBe('Validating and preprocessing input data for training.');
     expect(metadata.details).toEqual(
       expect.arrayContaining([
         { label: 'Duration', value: '1 m 32 s' },
@@ -306,5 +308,154 @@ describe('getStepMetadata', () => {
       { label: 'Duration', value: '1 m 42 s' },
       { label: 'Error', value: 'Component failed before stage map entry existed' },
     ]);
+  });
+
+  it('prefers curated descriptions over stage map copy', () => {
+    const componentStageMap: ComponentStageMap = {
+      pipeline_id: 'pipeline-1',
+      description: 'test',
+      kfp_run_id: 'run-1',
+      published_at: '2024-01-01T10:00:00Z',
+      components: [
+        {
+          id: 'automl_data_loader',
+          description: 'Data loader',
+          stages: [
+            {
+              id: 'prepare_data',
+              description: 'Stage map prepare data.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:00:10Z',
+            },
+            {
+              id: 'split_and_export',
+              description: 'Stage map split.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:00:20Z',
+            },
+          ],
+        },
+        {
+          id: 'training',
+          description: 'Training',
+          stages: [
+            {
+              id: 'load_data',
+              description: 'Stage map load data.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:00:30Z',
+            },
+            {
+              id: 'model_selection',
+              description: 'Stage map model selection.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:00:40Z',
+              steps: ['feature_engineering', 'model_training', 'stacking', 'evaluation'],
+            },
+            {
+              id: 'refit_full',
+              description: 'Stage map refit.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:01:00Z',
+            },
+            {
+              id: 'build_leaderboard',
+              description: 'Stage map leaderboard.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:01:10Z',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      getStepMetadata('automl_data_loader__prepare_data', 'Prepare data', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe('Validating and preprocessing input data for training.');
+    expect(
+      getStepMetadata('automl_data_loader__split_and_export', 'Split data', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe('Splitting data into training and test sets for model evaluation.');
+    expect(
+      getStepMetadata('training__load_data', 'Load data', 'completed', { componentStageMap })
+        .description,
+    ).toBe('Loading prepared data into the training workspace.');
+    expect(
+      getStepMetadata('training__model_selection', 'Select models', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe('Selecting candidate model architectures to train and evaluate.');
+    expect(
+      getStepMetadata(
+        'training__step__feature_engineering__branch-0',
+        'Engineer features',
+        'completed',
+        { componentStageMap },
+      ).description,
+    ).toBe('Transforming raw data into features for model training.');
+    expect(
+      getStepMetadata('training__step__model_training__branch-0', 'Train model', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe('Training the model using the prepared training data.');
+    expect(
+      getStepMetadata('training__step__stacking__branch-0', 'Stack predictions', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe('Combining predictions from multiple models to improve accuracy.');
+    expect(
+      getStepMetadata('training__step__evaluation__branch-0', 'Evaluate results', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe('Evaluating model performance against the test set.');
+    expect(
+      getStepMetadata('training__model__branch-0', 'XGBoost', 'completed', { componentStageMap })
+        .description,
+    ).toBe('The trained model candidate and its configuration.');
+    expect(
+      getStepMetadata('training__refit_full', 'Refit and evaluate', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe('Retraining top models using the complete dataset and evaluating final performance.');
+    expect(
+      getStepMetadata('training__build_leaderboard', 'Build leaderboard', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe('Ranking models by performance and generating the results leaderboard.');
+  });
+
+  it('falls back to stage map description when no curated mapping exists', () => {
+    const componentStageMap: ComponentStageMap = {
+      pipeline_id: 'pipeline-1',
+      description: 'test',
+      kfp_run_id: 'run-1',
+      published_at: '2024-01-01T10:00:00Z',
+      components: [
+        {
+          id: 'custom_component',
+          description: 'Custom',
+          stages: [
+            {
+              id: 'custom_unmapped_stage',
+              description: 'Custom stage map description.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:00:10Z',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      getStepMetadata(
+        'custom_component__custom_unmapped_stage',
+        'Custom unmapped stage',
+        'completed',
+        { componentStageMap },
+      ).description,
+    ).toBe('Custom stage map description.');
   });
 });

--- a/packages/automl/frontend/src/app/topology/tree-view/__tests__/transformStageMapNodesToTree.spec.ts
+++ b/packages/automl/frontend/src/app/topology/tree-view/__tests__/transformStageMapNodesToTree.spec.ts
@@ -157,9 +157,9 @@ describe('transformStageMapNodesToTree', () => {
     });
     const topologyNodes = [
       makeMockNode('training__load_data', 'Load data'),
-      makeMockNode('training__model_selection', 'Model selection'),
-      makeMockNode('training__branch-0__step__feature_engineering', 'Feature engineering'),
-      makeMockNode('training__branch-1__step__feature_engineering', 'Feature engineering'),
+      makeMockNode('training__model_selection', 'Select models'),
+      makeMockNode('training__branch-0__step__feature_engineering', 'Engineer features'),
+      makeMockNode('training__branch-1__step__feature_engineering', 'Engineer features'),
       makeMockNode('training__model__branch-0', 'Model 1'),
       makeMockNode('training__model__branch-1', 'Model 2'),
     ];
@@ -198,8 +198,8 @@ describe('transformStageMapNodesToTree', () => {
     const topologyNodes = [
       makeMockNode('training__load_data', 'Load data'),
       makeMockNode('training__step__validation', 'Step validation'),
-      makeMockNode('training__model_selection', 'Model selection'),
-      makeMockNode('training__step__feature_engineering__branch-0', 'Feature engineering'),
+      makeMockNode('training__model_selection', 'Select models'),
+      makeMockNode('training__step__feature_engineering__branch-0', 'Engineer features'),
       makeMockNode('training__model__branch-0', 'Model 1'),
       makeMockNode('training__refit_full', 'Refit full'),
     ];
@@ -227,13 +227,13 @@ describe('transformStageMapNodesToTree', () => {
     });
     const topologyNodes = [
       makeMockNode('training__load_data', 'Load data'),
-      makeMockNode('training__model_selection', 'Model selection'),
-      makeMockNode('training__step__feature_engineering__branch-0', 'Feature engineering'),
+      makeMockNode('training__model_selection', 'Select models'),
+      makeMockNode('training__step__feature_engineering__branch-0', 'Engineer features'),
       makeMockNode('training__model__branch-0', 'Model 1'),
       makeMockNode('training__refit_full', 'Refit full'),
       makeMockNode('training2__load_data', 'Load data'),
-      makeMockNode('training2__model_selection', 'Model selection'),
-      makeMockNode('training2__step__feature_engineering__branch-0', 'Feature engineering'),
+      makeMockNode('training2__model_selection', 'Select models'),
+      makeMockNode('training2__step__feature_engineering__branch-0', 'Engineer features'),
       makeMockNode('training2__model__branch-0', 'Model 2'),
       makeMockNode('training2__refit_full', 'Refit full'),
     ];
@@ -256,8 +256,8 @@ describe('transformStageMapNodesToTree', () => {
     const invalidBranchId = 'training__step__feature_engineering__branch-999999999999999999999';
     const topologyNodes = [
       makeMockNode('training__load_data', 'Load data'),
-      makeMockNode('training__model_selection', 'Model selection'),
-      makeMockNode(invalidBranchId, 'Feature engineering'),
+      makeMockNode('training__model_selection', 'Select models'),
+      makeMockNode(invalidBranchId, 'Engineer features'),
       makeMockNode('training__refit_full', 'Refit full'),
     ];
 

--- a/packages/automl/frontend/src/app/topology/tree-view/stepMetadata.ts
+++ b/packages/automl/frontend/src/app/topology/tree-view/stepMetadata.ts
@@ -15,6 +15,8 @@ import {
 export type StepDetail = {
   label: string;
   value: string;
+  /** Optional popover help shown next to the label. */
+  help?: { header: string; body: string };
 };
 
 export type StepMetadata = {
@@ -24,26 +26,30 @@ export type StepMetadata = {
 
 const DEFAULT_DETAILS: StepDetail[] = [{ label: 'Duration', value: '—' }];
 
+const BRANCH_MODEL_DESCRIPTION = 'The trained model candidate and its configuration.';
+
 /* eslint-disable camelcase -- keys match backend stage IDs */
 const STAGE_DESCRIPTIONS: Record<string, string> = {
   validate_inputs: 'Validating pipeline inputs and configuration before processing begins.',
   read_and_sample: 'Reading the dataset and sampling a representative subset for training.',
   cleanse: 'Cleaning and transforming raw data to prepare it for modeling.',
-  split: 'Splitting data into training and holdout sets.',
+  prepare_data: 'Validating and preprocessing input data for training.',
+  split: 'Splitting data into training and test sets for model evaluation.',
+  split_and_export: 'Splitting data into training and test sets for model evaluation.',
   write_outputs: 'Writing intermediate outputs from the data preparation phase.',
-  load_data: 'Loading prepared data for model training.',
-  model_selection:
-    'Evaluating candidate model families and selecting the top performers to train in parallel.',
-  refit_full: 'Retraining the best-performing models on the full training dataset.',
+  load_data: 'Loading prepared data into the training workspace.',
+  model_selection: 'Selecting candidate model architectures to train and evaluate.',
+  refit_full: 'Retraining top models using the complete dataset and evaluating final performance.',
   evaluate_models: 'Evaluating model performance on the holdout test set using configured metrics.',
-  build_leaderboard: 'Building the leaderboard and selecting the best model for deployment.',
+  build_leaderboard: 'Ranking models by performance and generating the results leaderboard.',
 };
 
 const STEP_DESCRIPTIONS: Record<string, string> = {
-  feature_engineering: 'Engineering and selecting features for the model training pipeline.',
-  model_training: 'Training base models with default hyperparameters.',
-  stacking: 'Building stacked ensembles from trained base models.',
-  model_evaluation: 'Evaluating model performance for this training path.',
+  feature_engineering: 'Transforming raw data into features for model training.',
+  model_training: 'Training the model using the prepared training data.',
+  stacking: 'Combining predictions from multiple models to improve accuracy.',
+  model_evaluation: 'Evaluating model performance against the test set.',
+  evaluation: 'Evaluating model performance against the test set.',
 };
 /* eslint-enable camelcase */
 
@@ -59,6 +65,31 @@ const extractStageId = (nodeId: string): string | undefined => {
 const extractStepId = (nodeId: string): string | undefined => {
   const match = /^.+__step__(.+)__branch-\d+$/.exec(nodeId);
   return match?.[1];
+};
+
+const getCuratedDescription = (nodeId: string): string | undefined => {
+  const parsed = parseStageMapNodeId(nodeId);
+  if (parsed?.type === 'stage' && Object.hasOwn(STAGE_DESCRIPTIONS, parsed.stageId)) {
+    return STAGE_DESCRIPTIONS[parsed.stageId];
+  }
+  if (parsed?.type === 'branch_step' && Object.hasOwn(STEP_DESCRIPTIONS, parsed.stepId)) {
+    return STEP_DESCRIPTIONS[parsed.stepId];
+  }
+  if (parsed?.type === 'branch_model') {
+    return BRANCH_MODEL_DESCRIPTION;
+  }
+
+  const stepId = extractStepId(nodeId);
+  if (stepId && Object.hasOwn(STEP_DESCRIPTIONS, stepId)) {
+    return STEP_DESCRIPTIONS[stepId];
+  }
+
+  const stageId = extractStageId(nodeId);
+  if (stageId && Object.hasOwn(STAGE_DESCRIPTIONS, stageId)) {
+    return STAGE_DESCRIPTIONS[stageId];
+  }
+
+  return undefined;
 };
 
 /** Find matching KFP task timing for a fallback topology node id. */
@@ -128,10 +159,14 @@ export const getStepMetadata = (
       };
     }
 
+    const curatedDescription = getCuratedDescription(nodeId);
     const mapDetails = getStageMapDetails(parsed, componentStageMap, pipelineRun, label, stepState);
     if (!mapDetails) {
       return {
-        description: getStageDescriptionFromMap(parsed, componentStageMap) ?? metadata.description,
+        description:
+          curatedDescription ??
+          getStageDescriptionFromMap(parsed, componentStageMap) ??
+          metadata.description,
         details: getDetailsFromPipelineRun(parsed.componentId, pipelineRun),
       };
     }
@@ -151,7 +186,7 @@ export const getStepMetadata = (
     }
 
     return {
-      description: mapDescription ?? metadata.description,
+      description: curatedDescription ?? mapDescription ?? metadata.description,
       details,
     };
   };
@@ -172,15 +207,14 @@ export const getStepMetadata = (
   if (stepId) {
     return resolveMetadata({
       description:
-        (Object.hasOwn(STEP_DESCRIPTIONS, stepId) ? STEP_DESCRIPTIONS[stepId] : undefined) ??
-        `Running ${resolveStepLabel(stepId)} for this model path.`,
+        getCuratedDescription(nodeId) ?? `Running ${resolveStepLabel(stepId)} for this model path.`,
       details: DEFAULT_DETAILS,
     });
   }
 
   if (/^.+__model__branch-\d+$/.test(nodeId)) {
     return resolveMetadata({
-      description: `Model training path for ${label}.`,
+      description: getCuratedDescription(nodeId) ?? BRANCH_MODEL_DESCRIPTION,
       details: DEFAULT_DETAILS,
     });
   }
@@ -188,9 +222,7 @@ export const getStepMetadata = (
   const stageId = extractStageId(nodeId);
   if (stageId) {
     return resolveMetadata({
-      description:
-        (Object.hasOwn(STAGE_DESCRIPTIONS, stageId) ? STAGE_DESCRIPTIONS[stageId] : undefined) ??
-        `Pipeline step: ${resolveStageLabel(stageId)}.`,
+      description: getCuratedDescription(nodeId) ?? `Pipeline step: ${resolveStageLabel(stageId)}.`,
       details: DEFAULT_DETAILS,
     });
   }

--- a/packages/automl/frontend/src/app/topology/useAutomlTaskTopology.ts
+++ b/packages/automl/frontend/src/app/topology/useAutomlTaskTopology.ts
@@ -8,9 +8,9 @@ const TASK_DISPLAY_NAMES: Record<string, string> = {
   'publish-component-stage-map': 'Pipeline preparation',
   'automl-data-loader': 'Input data loader',
   'timeseries-data-loader': 'Input data loader',
-  'models-selection': 'Model selection',
-  'timeseries-models-selection': 'Model selection',
-  'autogluon-timeseries-models-selection': 'Model selection',
+  'models-selection': 'Select models',
+  'timeseries-models-selection': 'Select models',
+  'autogluon-timeseries-models-selection': 'Select models',
   'for-loop-1': 'Model generation', // used in timeseries
   'autogluon-models-training': 'Model generation', // used in tabular
   'autogluon-models-training-2': 'Model generation', // speed preset variant
@@ -30,7 +30,7 @@ const normalizeTaskLookupKey = (s: string): string =>
 
 /**
  * Sentence-case fallback when no TASK_DISPLAY_NAMES entry matches
- * (matches entries like "Model selection", "Input data loader").
+ * (matches entries like "Select models", "Input data loader").
  */
 const fallbackTaskDisplayLabel = (name: string): string => {
   const spaced = name.trim().replace(/[-_]+/g, ' ').replace(/\s+/g, ' ');

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragPipelineVisualization.scss
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragPipelineVisualization.scss
@@ -10,14 +10,6 @@
   border-bottom: 1px solid var(--pf-t--global--border--color--default);
 }
 
-.autorag-pipeline-visualization__toolbar {
-  margin-left: auto;
-
-  .pf-v6-l-flex {
-    justify-content: flex-end;
-  }
-}
-
 .autorag-pipeline-visualization__body {
   height: 45vh;
   min-height: 45vh;
@@ -54,16 +46,4 @@
   height: 100%;
   min-height: 0;
   overflow: hidden;
-}
-
-@media (max-width: 992px) {
-  .autorag-pipeline-visualization__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .autorag-pipeline-visualization__toolbar {
-    margin-left: 0;
-    width: 100%;
-  }
 }

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragPipelineVisualization.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragPipelineVisualization.tsx
@@ -111,7 +111,11 @@ const AutoragPipelineVisualization: React.FC<AutoragPipelineVisualizationProps> 
               </Title>
             </FlexItem>
             <FlexItem>
-              <Label variant="outline" {...getPipelineStatusLabelProps(statusLabel)}>
+              <Label
+                variant="outline"
+                data-testid="run-status-label"
+                {...getPipelineStatusLabelProps(statusLabel)}
+              >
                 {statusLabel.text}
               </Label>
             </FlexItem>

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragPipelineVisualization.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragPipelineVisualization.tsx
@@ -102,14 +102,9 @@ const AutoragPipelineVisualization: React.FC<AutoragPipelineVisualizationProps> 
         className="autorag-pipeline-visualization__header"
         alignItems={{ default: 'alignItemsCenter' }}
         justifyContent={{ default: 'justifyContentSpaceBetween' }}
-        flexWrap={{ default: 'wrap' }}
-        spaceItems={{ default: 'spaceItemsMd' }}
       >
         <FlexItem>
-          <Flex
-            alignItems={{ default: 'alignItemsCenter' }}
-            spaceItems={{ default: 'spaceItemsMd' }}
-          >
+          <Flex>
             <FlexItem>
               <Title headingLevel="h3" size="lg">
                 {runTitle}
@@ -123,13 +118,8 @@ const AutoragPipelineVisualization: React.FC<AutoragPipelineVisualizationProps> 
           </Flex>
         </FlexItem>
 
-        <FlexItem className="autorag-pipeline-visualization__toolbar">
-          <Flex
-            alignItems={{ default: 'alignItemsCenter' }}
-            justifyContent={{ default: 'justifyContentFlexEnd' }}
-            spaceItems={{ default: 'spaceItemsMd' }}
-            flexWrap={{ default: 'wrap' }}
-          >
+        <FlexItem>
+          <Flex>
             <FlexItem>
               <Button
                 variant="tertiary"

--- a/packages/autorag/frontend/src/app/components/run-results/StepDetailsPanel.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/StepDetailsPanel.tsx
@@ -12,9 +12,11 @@ import {
   DrawerPanelBody,
   Label,
   Spinner,
+  type SpinnerProps,
   Stack,
   StackItem,
   Title,
+  type TitleProps,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
@@ -35,6 +37,7 @@ import {
   getPipelineStatusFilterLabel,
   getPipelineStatusLabelProps,
   getPipelineTreeLoadingContent,
+  getStepDetailsLoadingContent,
   getStepStateLabel,
   type PipelineStatusLabel,
   type PipelineTreeLoadingMode,
@@ -120,16 +123,20 @@ const StepDetailsPanelHeader: React.FC<StepDetailsPanelHeaderProps> = ({
 type StepDetailsLoadingBodyProps = {
   primaryText: string;
   secondaryText: string;
+  spinnerSize?: SpinnerProps['size'];
+  titleSize?: TitleProps['size'];
 };
 
 const StepDetailsLoadingBody: React.FC<StepDetailsLoadingBodyProps> = ({
   primaryText,
   secondaryText,
+  spinnerSize = 'xl',
+  titleSize = 'xl',
 }) => (
   <div className="autorag-step-details__empty-state">
     <div className="autorag-step-details__empty-state-content">
-      <Spinner size="xl" className="autorag-step-details__empty-state-spinner" />
-      <Title headingLevel="h3" size="xl" className="autorag-step-details__empty-state-title">
+      <Spinner size={spinnerSize} className="autorag-step-details__empty-state-spinner" />
+      <Title headingLevel="h3" size={titleSize} className="autorag-step-details__empty-state-title">
         {primaryText}
       </Title>
       <Content component={ContentVariants.p} className="autorag-step-details__empty-state-subtitle">
@@ -235,7 +242,7 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
     nodeData.stepState === 'completed';
   const panelTitle = isBestPattern ? 'Best pattern' : (nodeData.label ?? 'Step details');
   const statusLabel = getStepStateLabel(nodeData.stepState);
-  const inProgressLoadingContent = getPipelineDetailsEmptyContent('in-progress');
+  const inProgressLoadingContent = getStepDetailsLoadingContent();
   const isStepLoading = nodeData.stepState === 'active';
 
   return (
@@ -268,6 +275,8 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
               <StepDetailsLoadingBody
                 primaryText={inProgressLoadingContent.primaryText ?? inProgressLoadingContent.title}
                 secondaryText={inProgressLoadingContent.secondaryText ?? ''}
+                spinnerSize="lg"
+                titleSize="lg"
               />
             </StackItem>
           ) : (

--- a/packages/autorag/frontend/src/app/components/run-results/StepDetailsPanel.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/StepDetailsPanel.tsx
@@ -10,7 +10,10 @@ import {
   DrawerCloseButton,
   DrawerHead,
   DrawerPanelBody,
+  Flex,
+  FlexItem,
   Label,
+  Popover,
   Spinner,
   type SpinnerProps,
   Stack,
@@ -18,15 +21,16 @@ import {
   Title,
   type TitleProps,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { DashboardPopupIconButton } from 'mod-arch-shared';
 import React from 'react';
 import { useAutoragResultsContext } from '~/app/context/AutoragResultsContext';
 import type { ComponentStageMap } from '~/app/hooks/useComponentStageMap';
 import type { PipelineRun } from '~/app/types';
 import type { AutoragPattern } from '~/app/types/autoragPattern';
-import { getSelectedPatterns } from '~/app/topology/stageMapStatus';
+import { getSelectedPatterns, BRANCHING_STAGE_ID } from '~/app/topology/stageMapStatus';
 import type { PipelineStatusFilter } from '~/app/topology/tree-view/types';
-import { getStepMetadata } from '~/app/topology/tree-view/stepMetadata';
+import { getStepMetadata, type StepDetail } from '~/app/topology/tree-view/stepMetadata';
 import {
   parseStageMapNodeId,
   type ParsedStageMapNode,
@@ -80,6 +84,38 @@ const resolveBranchPatternKey = (
   }
   const patternKey = branchPatterns[parsedNodeId.branchIndex];
   return patternKey && Object.hasOwn(patterns, patternKey) ? patternKey : undefined;
+};
+
+type StepDetailTermProps = {
+  detail: StepDetail;
+};
+
+const StepDetailTerm: React.FC<StepDetailTermProps> = ({ detail }) => {
+  if (!detail.help) {
+    return <DescriptionListTerm>{detail.label}</DescriptionListTerm>;
+  }
+
+  return (
+    <DescriptionListTerm>
+      <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapXs' }}>
+        <FlexItem>{detail.label}</FlexItem>
+        <FlexItem>
+          <Popover
+            aria-label={`${detail.help.header} help`}
+            headerContent={detail.help.header}
+            bodyContent={detail.help.body}
+          >
+            <DashboardPopupIconButton
+              aria-label={`More info for ${detail.label.toLowerCase()}`}
+              icon={<OutlinedQuestionCircleIcon />}
+              hasNoPadding
+              data-testid={`step-detail-help-${detail.label.toLowerCase().replace(/\s+/g, '-')}`}
+            />
+          </Popover>
+        </FlexItem>
+      </Flex>
+    </DescriptionListTerm>
+  );
 };
 
 type StepDetailsPanelHeaderProps = {
@@ -198,23 +234,16 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
                 </Content>
               </StackItem>
               {showPipelineSummary && (
-                <>
-                  <StackItem>
-                    <Title headingLevel="h4" size="md">
-                      Details
-                    </Title>
-                  </StackItem>
-                  <StackItem>
-                    <DescriptionList isCompact data-testid="pipeline-summary-details">
-                      {pipelineSummaryDetails.map((detail, index) => (
-                        <DescriptionListGroup key={`${detail.label}-${index}`}>
-                          <DescriptionListTerm>{detail.label}:</DescriptionListTerm>
-                          <DescriptionListDescription>{detail.value}</DescriptionListDescription>
-                        </DescriptionListGroup>
-                      ))}
-                    </DescriptionList>
-                  </StackItem>
-                </>
+                <StackItem>
+                  <DescriptionList isCompact data-testid="pipeline-summary-details">
+                    {pipelineSummaryDetails.map((detail, index) => (
+                      <DescriptionListGroup key={`${detail.label}-${index}`}>
+                        <StepDetailTerm detail={detail} />
+                        <DescriptionListDescription>{detail.value}</DescriptionListDescription>
+                      </DescriptionListGroup>
+                    ))}
+                  </DescriptionList>
+                </StackItem>
               )}
             </Stack>
           )}
@@ -244,6 +273,8 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
   const statusLabel = getStepStateLabel(nodeData.stepState);
   const inProgressLoadingContent = getStepDetailsLoadingContent();
   const isStepLoading = nodeData.stepState === 'active';
+  const isBranchingStage =
+    parsedNodeId?.type === 'stage' && parsedNodeId.stageId === BRANCHING_STAGE_ID;
 
   return (
     <>
@@ -258,8 +289,10 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
                 customIcon={<ExclamationCircleIcon />}
                 data-testid="step-failed-alert"
               >
-                The pipeline stopped during {panelTitle}. Branch steps are reported as a single
-                group — remaining steps were not run.
+                The pipeline stopped during {panelTitle}.
+                {isBranchingStage
+                  ? ' Branch steps are reported as a single group — remaining steps were not run.'
+                  : null}
               </Alert>
             </StackItem>
           )}
@@ -280,24 +313,16 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
               />
             </StackItem>
           ) : (
-            <>
-              <StackItem>
-                <Title headingLevel="h4" size="md">
-                  Details
-                </Title>
-              </StackItem>
-
-              <StackItem>
-                <DescriptionList isCompact>
-                  {metadata.details.map((detail, index) => (
-                    <DescriptionListGroup key={`${detail.label}-${index}`}>
-                      <DescriptionListTerm>{detail.label}:</DescriptionListTerm>
-                      <DescriptionListDescription>{detail.value}</DescriptionListDescription>
-                    </DescriptionListGroup>
-                  ))}
-                </DescriptionList>
-              </StackItem>
-            </>
+            <StackItem>
+              <DescriptionList isCompact>
+                {metadata.details.map((detail, index) => (
+                  <DescriptionListGroup key={`${detail.label}-${index}`}>
+                    <StepDetailTerm detail={detail} />
+                    <DescriptionListDescription>{detail.value}</DescriptionListDescription>
+                  </DescriptionListGroup>
+                ))}
+              </DescriptionList>
+            </StackItem>
           )}
         </Stack>
       </DrawerPanelBody>

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/pipelineStatusLabels.spec.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/pipelineStatusLabels.spec.ts
@@ -81,7 +81,7 @@ describe('pipeline status label fallbacks', () => {
     expect(getPipelineDetailsEmptyContent(unknownStatus)).toEqual({
       title: 'Pipeline details',
       variant: 'idle',
-      secondaryText: 'Click on any node in the pipeline to view its details here.',
+      secondaryText: 'Select a step to view its details.',
     });
   });
 });

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/pipelineSummaryMetadata.spec.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/pipelineSummaryMetadata.spec.ts
@@ -67,8 +67,22 @@ describe('getPipelineSummaryDetails', () => {
 
     expect(details).toEqual([
       { label: 'Total run time', value: '2 m 55 s' },
-      { label: 'Patterns evaluated', value: '2' },
-      { label: 'Winning pattern', value: 'Pattern1' },
+      {
+        label: 'Patterns evaluated',
+        value: '2',
+        help: {
+          header: 'Pattern',
+          body: 'A specific combination of chunking, embedding, retrieval, and generation settings being tested.',
+        },
+      },
+      {
+        label: 'Winning pattern',
+        value: 'Pattern1',
+        help: {
+          header: 'Winning pattern',
+          body: 'The configuration that achieved the highest evaluation score during optimization.',
+        },
+      },
       {
         label: 'Evaluation metric',
         value: OPTIMIZATION_METRIC_LABELS[DEFAULT_OPTIMIZATION_METRIC],
@@ -160,8 +174,22 @@ describe('getPipelineSummaryDetails', () => {
 
     expect(details).toEqual([
       { label: 'Total run time', value: '—' },
-      { label: 'Patterns evaluated', value: '—' },
-      { label: 'Winning pattern', value: '—' },
+      {
+        label: 'Patterns evaluated',
+        value: '—',
+        help: {
+          header: 'Pattern',
+          body: 'A specific combination of chunking, embedding, retrieval, and generation settings being tested.',
+        },
+      },
+      {
+        label: 'Winning pattern',
+        value: '—',
+        help: {
+          header: 'Winning pattern',
+          body: 'The configuration that achieved the highest evaluation score during optimization.',
+        },
+      },
       {
         label: 'Evaluation metric',
         value: OPTIMIZATION_METRIC_LABELS[DEFAULT_OPTIMIZATION_METRIC],

--- a/packages/autorag/frontend/src/app/components/run-results/pipelineStatusLabels.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/pipelineStatusLabels.ts
@@ -152,6 +152,13 @@ export type PipelineDetailsEmptyContent = {
   secondaryText?: string;
 };
 
+export const getStepDetailsLoadingContent = (): PipelineDetailsEmptyContent => ({
+  title: 'Running task',
+  variant: 'loading',
+  primaryText: 'Running task',
+  secondaryText: 'Details will appear once this step is complete.',
+});
+
 export const getPipelineDetailsEmptyContent = (
   statusFilter: PipelineStatusFilter,
 ): PipelineDetailsEmptyContent => {

--- a/packages/autorag/frontend/src/app/components/run-results/pipelineStatusLabels.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/pipelineStatusLabels.ts
@@ -44,9 +44,9 @@ export const getPipelineTreeLoadingContent = (
   switch (mode) {
     case 'preparing':
       return {
-        title: 'Preparing pipeline',
-        primaryText: 'Starting your evaluation, this may take a few moments',
-        secondaryText: 'The pipeline visualization will appear when the run structure is ready.',
+        title: 'Starting evaluation',
+        primaryText: 'Starting evaluation',
+        secondaryText: 'This might take a few moments.',
       };
     case 'hydrating':
     default:
@@ -165,17 +165,17 @@ export const getPipelineDetailsEmptyContent = (
   switch (statusFilter) {
     case 'loading':
       return {
-        title: 'Preparing pipeline',
+        title: 'Starting evaluation',
         variant: 'loading',
-        primaryText: 'Preparing pipeline',
-        secondaryText: 'Pipeline steps will appear on the left once the run structure is ready.',
+        primaryText: 'Starting evaluation',
+        secondaryText: 'This might take a few moments.',
       };
     case 'in-progress':
       return {
         title: 'Running pipeline',
         variant: 'loading',
-        primaryText: 'Running pipeline',
-        secondaryText: 'Details will appear once the step is complete.',
+        primaryText: 'Pipeline run in progress',
+        secondaryText: 'Step details will become available as steps complete.',
       };
     case 'completed':
     case 'canceled':
@@ -184,7 +184,7 @@ export const getPipelineDetailsEmptyContent = (
       return {
         title: 'Pipeline details',
         variant: 'idle',
-        secondaryText: 'Click on any node in the pipeline to view its details here.',
+        secondaryText: 'Select a step to view its details.',
       };
   }
 };

--- a/packages/autorag/frontend/src/app/components/run-results/pipelineSummaryMetadata.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/pipelineSummaryMetadata.ts
@@ -117,10 +117,18 @@ export function getPipelineSummaryDetails(
     {
       label: 'Patterns evaluated',
       value: resolvePatternsEvaluated(componentStageMap, patterns)?.toString() ?? '—',
+      help: {
+        header: 'Pattern',
+        body: 'A specific combination of chunking, embedding, retrieval, and generation settings being tested.',
+      },
     },
     {
       label: 'Winning pattern',
       value: resolveWinningPatternDisplay(patterns, bestPatternKey) ?? '—',
+      help: {
+        header: 'Winning pattern',
+        body: 'The configuration that achieved the highest evaluation score during optimization.',
+      },
     },
     {
       label: 'Evaluation metric',

--- a/packages/autorag/frontend/src/app/hooks/__tests__/patternSchema.spec.ts
+++ b/packages/autorag/frontend/src/app/hooks/__tests__/patternSchema.spec.ts
@@ -156,6 +156,25 @@ describe('AutoragPatternSchema', () => {
     const result = AutoragPatternSchema.safeParse({ ...v1Pattern, settings });
     expect(result.success).toBe(true);
   });
+
+  it('should parse a V2 pattern with null vector_store_id', () => {
+    // Real pipeline may set vector_store_id to null when no collection is bound.
+    const withNullBinding = {
+      ...v2Pattern,
+      settings: {
+        ...v2Pattern.settings,
+        vector_store_binding: {
+          ...v2Pattern.settings.vector_store_binding,
+          vector_store_id: null,
+        },
+      },
+    };
+    const result = AutoragPatternSchema.safeParse(withNullBinding);
+    expect(result.success).toBe(true);
+    if (result.success && 'settings' in result.data) {
+      expect(result.data.settings.vector_store_binding?.vector_store_id).toBeNull();
+    }
+  });
 });
 
 describe('isV1RawPattern', () => {

--- a/packages/autorag/frontend/src/app/hooks/__tests__/queries.spec.ts
+++ b/packages/autorag/frontend/src/app/hooks/__tests__/queries.spec.ts
@@ -1,13 +1,20 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
-import { fetchS3File, fetchS3Json, useSecretCredentialsQuery } from '~/app/hooks/queries';
-import { getSecretByName } from '~/app/api/k8s';
+import {
+  fetchS3File,
+  fetchS3Json,
+  useOgxModelsQuery,
+  useSecretCredentialsQuery,
+} from '~/app/hooks/queries';
+import { getOgxModels, getSecretByName } from '~/app/api/k8s';
 
 jest.mock('~/app/api/k8s', () => ({
+  getOgxModels: jest.fn(),
   getSecretByName: jest.fn(),
 }));
 
+const getOgxModelsMock = jest.mocked(getOgxModels);
 const getSecretByNameMock = jest.mocked(getSecretByName);
 
 global.fetch = jest.fn();
@@ -268,5 +275,131 @@ describe('useSecretCredentialsQuery', () => {
     });
 
     expect(result.current.error?.message).toBe('Not found');
+  });
+});
+
+describe('useOgxModelsQuery', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+    return Wrapper;
+  };
+
+  const mockModel = (id: string, type: string) => ({
+    id,
+    type,
+    provider: 'openai',
+    resource_path: `/${id}`, // eslint-disable-line camelcase
+  });
+
+  const mockModelsResponse = (models: ReturnType<typeof mockModel>[]) => {
+    getOgxModelsMock.mockReturnValue((() => () => Promise.resolve({ models })) as never);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be disabled when namespace is empty', () => {
+    const { result } = renderHook(() => useOgxModelsQuery('', 'secret'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('should be disabled when secretName is empty', () => {
+    const { result } = renderHook(() => useOgxModelsQuery('ns', ''), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('should return only llm and embedding models', async () => {
+    mockModelsResponse([mockModel('model-1', 'llm'), mockModel('model-2', 'embedding')]);
+
+    const { result } = renderHook(() => useOgxModelsQuery('ns', 'secret'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.models).toHaveLength(2);
+    expect(result.current.data?.models.map((m) => m.id)).toEqual(['model-1', 'model-2']);
+  });
+
+  it('should filter out unknown model types', async () => {
+    mockModelsResponse([
+      mockModel('llm-1', 'llm'),
+      mockModel('reranker-1', 'reranker'),
+      mockModel('embed-1', 'embedding'),
+      mockModel('speech-1', 'speech-to-text'),
+    ]);
+
+    const { result } = renderHook(() => useOgxModelsQuery('ns', 'secret'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.models).toHaveLength(2);
+    expect(result.current.data?.models.map((m) => m.id)).toEqual(['llm-1', 'embed-1']);
+  });
+
+  it('should return empty models when all types are unknown', async () => {
+    mockModelsResponse([mockModel('reranker-1', 'reranker'), mockModel('tts-1', 'text-to-speech')]);
+
+    const { result } = renderHook(() => useOgxModelsQuery('ns', 'secret'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.models).toHaveLength(0);
+  });
+
+  it('should apply modelType select filter on top of type filtering', async () => {
+    mockModelsResponse([
+      mockModel('llm-1', 'llm'),
+      mockModel('embed-1', 'embedding'),
+      mockModel('reranker-1', 'reranker'),
+    ]);
+
+    const { result } = renderHook(() => useOgxModelsQuery('ns', 'secret', 'llm'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.models).toHaveLength(1);
+    expect(result.current.data?.models[0].id).toBe('llm-1');
+  });
+
+  it('should throw on invalid response structure', async () => {
+    getOgxModelsMock.mockReturnValue((() => () => Promise.resolve({ invalid: 'data' })) as never);
+
+    const { result } = renderHook(() => useOgxModelsQuery('ns', 'secret'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe('Invalid Open GenAI Stack models response');
   });
 });

--- a/packages/autorag/frontend/src/app/hooks/patternSchema.ts
+++ b/packages/autorag/frontend/src/app/hooks/patternSchema.ts
@@ -69,7 +69,8 @@ const VectorStoreBindingSchema = z
   .object({
     provider_id: z.string(),
     provider_type: z.string(),
-    vector_store_id: z.string(),
+    // Pipeline output may emit null when no collection was bound
+    vector_store_id: z.string().nullable(),
   })
   .passthrough();
 

--- a/packages/autorag/frontend/src/app/hooks/queries.ts
+++ b/packages/autorag/frontend/src/app/hooks/queries.ts
@@ -26,18 +26,25 @@ export function useOgxModelsQuery(
     queryFn: async () => {
       try {
         const response = await getOgxModels('')(namespace, secretName)({});
-        z.object({
-          models: z.array(
-            z.object({
-              id: z.string(),
-              type: z.union([z.literal('llm'), z.literal('embedding')]),
-              provider: z.string(),
-              // eslint-disable-next-line camelcase
-              resource_path: z.string(),
-            }),
+        const validated = z
+          .object({
+            models: z.array(
+              z.object({
+                id: z.string(),
+                type: z.string(),
+                provider: z.string(),
+                // eslint-disable-next-line camelcase
+                resource_path: z.string(),
+              }),
+            ),
+          })
+          .parse(response);
+        return {
+          models: validated.models.filter(
+            (m): m is typeof m & { type: 'llm' | 'embedding' } =>
+              m.type === 'llm' || m.type === 'embedding',
           ),
-        }).parse(response);
-        return response;
+        };
       } catch (error) {
         if (error instanceof z.ZodError) {
           throw new Error('Invalid Open GenAI Stack models response');

--- a/packages/autorag/frontend/src/app/topology/__tests__/buildStageMapTopology.spec.ts
+++ b/packages/autorag/frontend/src/app/topology/__tests__/buildStageMapTopology.spec.ts
@@ -256,9 +256,9 @@ describe('buildStageMapTopology', () => {
       const step2 = nodes.find((n) => n.id === 'rag_optimization__step__embedding__branch-0');
       const step3 = nodes.find((n) => n.id === 'rag_optimization__step__retrieval__branch-0');
 
-      expect(step1?.label).toBe('Chunking');
-      expect(step2?.label).toBe('Embedding');
-      expect(step3?.label).toBe('Retrieval');
+      expect(step1?.label).toBe('Chunk documents');
+      expect(step2?.label).toBe('Generate embeddings');
+      expect(step3?.label).toBe('Retrieve documents');
     });
 
     it('should cap branch step expansion to MAX_PATTERN_SELECTION_STEPS', () => {

--- a/packages/autorag/frontend/src/app/topology/__tests__/parseUtils.spec.ts
+++ b/packages/autorag/frontend/src/app/topology/__tests__/parseUtils.spec.ts
@@ -95,14 +95,14 @@ describe('parseRuntimeInfoFromRunDetails', () => {
     expect(result?.state).toBe(RuntimeStateKF.FAILED);
   });
 
-  it('should pick worst status when main and driver tasks both exist', () => {
+  it('should prefer the executor status over the driver when both exist', () => {
     const details = makeRunDetails(
       { task_id: 'task-1', display_name: 'task-1', state: RuntimeStateKF.SUCCEEDED },
       { task_id: 'task-1-driver', display_name: 'task-1-driver', state: RuntimeStateKF.FAILED },
     );
     const result = parseRuntimeInfoFromRunDetails('task-1', details);
 
-    expect(result?.state).toBe(RuntimeStateKF.FAILED);
+    expect(result?.state).toBe(RuntimeStateKF.SUCCEEDED);
   });
 
   it('should keep succeeded when paired with canceled driver status', () => {
@@ -115,14 +115,14 @@ describe('parseRuntimeInfoFromRunDetails', () => {
     expect(result?.state).toBe(RuntimeStateKF.SUCCEEDED);
   });
 
-  it('should pick failed over canceled', () => {
+  it('should prefer the executor status over the driver even when the driver failed', () => {
     const details = makeRunDetails(
       { task_id: 'task-1', display_name: 'task-1', state: RuntimeStateKF.CANCELED },
       { task_id: 'task-1-driver', display_name: 'task-1-driver', state: RuntimeStateKF.FAILED },
     );
     const result = parseRuntimeInfoFromRunDetails('task-1', details);
 
-    expect(result?.state).toBe(RuntimeStateKF.FAILED);
+    expect(result?.state).toBe(RuntimeStateKF.CANCELED);
   });
 });
 

--- a/packages/autorag/frontend/src/app/topology/__tests__/stageMapLabels.spec.ts
+++ b/packages/autorag/frontend/src/app/topology/__tests__/stageMapLabels.spec.ts
@@ -4,7 +4,9 @@ describe('resolveStageLabel', () => {
   it('returns mapped display names for known stage IDs', () => {
     expect(resolveStageLabel('optimize_templates')).toBe('Optimize templates');
     expect(resolveStageLabel('prepare_data')).toBe('Prepare data');
-    expect(resolveStageLabel('build_leaderboard')).toBe('Build leaderboard');
+    expect(resolveStageLabel('build_leaderboard')).toBe('Select best pattern');
+    expect(resolveStageLabel('load_benchmark')).toBe('Load benchmark');
+    expect(resolveStageLabel('discover_documents')).toBe('Discover documents');
   });
 
   it('falls back for unknown stage IDs', () => {
@@ -19,8 +21,11 @@ describe('resolveStageLabel', () => {
 
 describe('resolveStepLabel', () => {
   it('returns mapped display names for known step IDs', () => {
-    expect(resolveStepLabel('chunking')).toBe('Chunking');
-    expect(resolveStepLabel('embedding')).toBe('Embedding');
+    expect(resolveStepLabel('chunking')).toBe('Chunk documents');
+    expect(resolveStepLabel('embedding')).toBe('Generate embeddings');
+    expect(resolveStepLabel('retrieval')).toBe('Retrieve documents');
+    expect(resolveStepLabel('generation')).toBe('Generate responses');
+    expect(resolveStepLabel('evaluation')).toBe('Evaluate results');
   });
 
   it('falls back for unknown step IDs', () => {

--- a/packages/autorag/frontend/src/app/topology/__tests__/stageMapStatus.spec.ts
+++ b/packages/autorag/frontend/src/app/topology/__tests__/stageMapStatus.spec.ts
@@ -173,7 +173,7 @@ describe('getComponentRunStatus', () => {
     expect(getComponentRunStatus(component, undefined)).toBe(RunStatus.Succeeded);
   });
 
-  it('should include driver task variants and prefer the worst matching status', () => {
+  it('should include driver task variants and prefer the executor status', () => {
     const component = makeComponent();
     const runDetails = {
       task_details: [
@@ -198,7 +198,7 @@ describe('getComponentRunStatus', () => {
       ],
     } as RunDetailsKF;
 
-    expect(getComponentRunStatus(component, runDetails)).toBe(RunStatus.Failed);
+    expect(getComponentRunStatus(component, runDetails)).toBe(RunStatus.Succeeded);
   });
 });
 

--- a/packages/autorag/frontend/src/app/topology/parseUtils.ts
+++ b/packages/autorag/frontend/src/app/topology/parseUtils.ts
@@ -40,7 +40,11 @@ const worstStatus = (details: TaskDetailKF[]): TaskDetailKF['state'] =>
 
 /**
  * Get the run status of a task from the RunDetailsKF (task_details array).
- * Considers both the main task and its driver task, picking the most-progressed status.
+ * The `-driver` task only resolves inputs/caching and can finish independently of the
+ * actual executor container — e.g. it may report SUCCEEDED before the executor even starts,
+ * or CANCELED as cleanup after the executor has already finished. Its state must never
+ * override the executor's real state, so the executor entry (if present) is authoritative;
+ * the driver entry is only used as a fallback before the executor appears in task_details.
  */
 export const parseRuntimeInfoFromRunDetails = (
   taskId: string,
@@ -50,7 +54,11 @@ export const parseRuntimeInfoFromRunDetails = (
     return undefined;
   }
 
-  const nameVariants = [taskId, `${taskId}-driver`];
+  const driverName = `${taskId}-driver`;
+  const isDriverEntry = (td: TaskDetailKF): boolean =>
+    td.display_name === driverName || td.task_id === driverName;
+
+  const nameVariants = [taskId, driverName];
   const matchingDetails = runDetails.task_details.filter(
     (td) =>
       (td.display_name != null && nameVariants.includes(td.display_name)) ||
@@ -61,11 +69,14 @@ export const parseRuntimeInfoFromRunDetails = (
     return undefined;
   }
 
+  const executorDetails = matchingDetails.filter((td) => !isDriverEntry(td));
+  const relevantDetails = executorDetails.length > 0 ? executorDetails : matchingDetails;
+
   return {
-    startTime: matchingDetails[0].start_time,
-    completeTime: matchingDetails[0].end_time,
-    state: worstStatus(matchingDetails),
-    taskId: matchingDetails[0].task_id,
+    startTime: relevantDetails[0].start_time,
+    completeTime: relevantDetails[0].end_time,
+    state: worstStatus(relevantDetails),
+    taskId: relevantDetails[0].task_id,
   };
 };
 

--- a/packages/autorag/frontend/src/app/topology/stageMapLabels.ts
+++ b/packages/autorag/frontend/src/app/topology/stageMapLabels.ts
@@ -8,6 +8,8 @@ export const STAGE_DISPLAY_NAMES: Record<string, string> = {
   list_and_sample: 'List and sample',
   write_descriptor: 'Write descriptor',
   load_descriptor: 'Load descriptor',
+  load_benchmark: 'Load benchmark',
+  discover_documents: 'Discover documents',
   extract_documents: 'Extract documents',
   prepare_search_space: 'Prepare search space',
   write_report: 'Write report',
@@ -16,15 +18,15 @@ export const STAGE_DISPLAY_NAMES: Record<string, string> = {
   write_patterns: 'Write patterns',
   build_requests: 'Build requests',
   write_artifacts: 'Write artifacts',
-  build_leaderboard: 'Build leaderboard',
+  build_leaderboard: 'Select best pattern',
 };
 
 export const STEP_DISPLAY_NAMES: Record<string, string> = {
-  chunking: 'Chunking',
-  embedding: 'Embedding',
-  retrieval: 'Retrieval',
-  generation: 'Generation',
-  evaluation: 'Evaluation',
+  chunking: 'Chunk documents',
+  embedding: 'Generate embeddings',
+  retrieval: 'Retrieve documents',
+  generation: 'Generate responses',
+  evaluation: 'Evaluate results',
 };
 
 const fallbackStageLabel = (stageId: string): string => {

--- a/packages/autorag/frontend/src/app/topology/tree-view/__tests__/stepMetadata.spec.ts
+++ b/packages/autorag/frontend/src/app/topology/tree-view/__tests__/stepMetadata.spec.ts
@@ -135,7 +135,9 @@ describe('getStepMetadata', () => {
       componentStageMap,
     });
 
-    expect(metadata.description).toBe('Validating inputs from the stage map.');
+    expect(metadata.description).toBe(
+      'Validating pipeline inputs and configuration before processing begins.',
+    );
     expect(metadata.details[0]).toEqual({ label: 'Duration', value: '10 s' });
   });
 
@@ -186,7 +188,9 @@ describe('getStepMetadata', () => {
       },
     );
 
-    expect(metadata.description).toBe('Download and sample from the stage map.');
+    expect(metadata.description).toBe(
+      'Downloading the source documents and sampling a representative subset for evaluation.',
+    );
     expect(metadata.details).toEqual(
       expect.arrayContaining([
         { label: 'Duration', value: '10 s' },
@@ -316,5 +320,145 @@ describe('getStepMetadata', () => {
       { label: 'Duration', value: '1 m 42 s' },
       { label: 'Error', value: 'Component failed before stage map entry existed' },
     ]);
+  });
+
+  it('prefers curated stage descriptions over stage map copy', () => {
+    const componentStageMap: ComponentStageMap = {
+      pipeline_id: 'pipeline-1',
+      description: 'test',
+      kfp_run_id: 'run-1',
+      published_at: '2024-01-01T10:00:00Z',
+      components: [
+        {
+          id: 'test_data_loader',
+          description: 'Test data',
+          stages: [
+            {
+              id: 'load_benchmark',
+              description: 'Stage map load benchmark description.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:00:10Z',
+            },
+            {
+              id: 'optimize_templates',
+              description: 'Stage map optimize templates description.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:01:00Z',
+            },
+            {
+              id: 'build_leaderboard',
+              description: 'Stage map build leaderboard description.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:02:00Z',
+            },
+          ],
+        },
+        {
+          id: 'documents_discovery',
+          description: 'Documents',
+          stages: [
+            {
+              id: 'discover_documents',
+              description: 'Stage map discover documents description.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:00:20Z',
+            },
+            {
+              id: 'extract_documents',
+              description: 'Stage map extract documents description.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:00:30Z',
+            },
+            {
+              id: 'prepare_search_space',
+              description: 'Stage map prepare search space description.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:00:40Z',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      getStepMetadata('test_data_loader__load_benchmark', 'Load benchmark', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe('Loading the benchmark and metrics configuration.');
+    expect(
+      getStepMetadata(
+        'documents_discovery__discover_documents',
+        'Discover documents',
+        'completed',
+        {
+          componentStageMap,
+        },
+      ).description,
+    ).toBe('Scanning knowledge sources for documents.');
+    expect(
+      getStepMetadata('documents_discovery__extract_documents', 'Extract documents', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe('Extracting and normalizing document content.');
+    expect(
+      getStepMetadata(
+        'documents_discovery__prepare_search_space',
+        'Prepare search space',
+        'completed',
+        { componentStageMap },
+      ).description,
+    ).toBe('Chunking documents and indexing embeddings in the vector store.');
+    expect(
+      getStepMetadata('test_data_loader__optimize_templates', 'Optimize templates', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe(
+      'Testing prompt templates across parallel branches. Branch steps will show as pending until all branches complete.',
+    );
+    expect(
+      getStepMetadata('test_data_loader__build_leaderboard', 'Select best pattern', 'completed', {
+        componentStageMap,
+      }).description,
+    ).toBe('Selecting the best-performing pattern for deployment.');
+    expect(
+      getStepMetadata(
+        'rag_optimization__step__evaluation__branch-0',
+        'Evaluate results',
+        'completed',
+        { componentStageMap },
+      ).description,
+    ).toBe('Comprehensive evaluation of the final pattern using holdout test data.');
+  });
+
+  it('falls back to stage map description when no curated mapping exists', () => {
+    const componentStageMap: ComponentStageMap = {
+      pipeline_id: 'pipeline-1',
+      description: 'test',
+      kfp_run_id: 'run-1',
+      published_at: '2024-01-01T10:00:00Z',
+      components: [
+        {
+          id: 'custom_component',
+          description: 'Custom',
+          stages: [
+            {
+              id: 'custom_unmapped_stage',
+              description: 'Custom stage map description.',
+              status: 'completed',
+              timestamp: '2024-01-01T10:00:10Z',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      getStepMetadata(
+        'custom_component__custom_unmapped_stage',
+        'Custom unmapped stage',
+        'completed',
+        { componentStageMap },
+      ).description,
+    ).toBe('Custom stage map description.');
   });
 });

--- a/packages/autorag/frontend/src/app/topology/tree-view/__tests__/transformStageMapNodesToTree.spec.ts
+++ b/packages/autorag/frontend/src/app/topology/tree-view/__tests__/transformStageMapNodesToTree.spec.ts
@@ -160,8 +160,8 @@ describe('transformStageMapNodesToTree', () => {
     const topologyNodes = [
       makeMockNode('rag_optimization__validate_inputs', 'Validate inputs'),
       makeMockNode('rag_optimization__optimize_templates', 'Optimize templates'),
-      makeMockNode('rag_optimization__branch-0__step__chunking', 'Chunking'),
-      makeMockNode('rag_optimization__branch-1__step__chunking', 'Chunking'),
+      makeMockNode('rag_optimization__branch-0__step__chunking', 'Chunk documents'),
+      makeMockNode('rag_optimization__branch-1__step__chunking', 'Chunk documents'),
       makeMockNode('rag_optimization__pattern__branch-0', 'Pattern 1'),
       makeMockNode('rag_optimization__pattern__branch-1', 'Pattern 2'),
     ];
@@ -203,7 +203,7 @@ describe('transformStageMapNodesToTree', () => {
       makeMockNode('rag_optimization__validate_inputs', 'Validate inputs'),
       makeMockNode('rag_optimization__step__validation', 'Step validation'),
       makeMockNode('rag_optimization__optimize_templates', 'Optimize templates'),
-      makeMockNode('rag_optimization__step__chunking__branch-0', 'Chunking'),
+      makeMockNode('rag_optimization__step__chunking__branch-0', 'Chunk documents'),
       makeMockNode('rag_optimization__pattern__branch-0', 'Pattern 1'),
       makeMockNode('rag_optimization__run_optimization', 'Run optimization'),
     ];
@@ -232,12 +232,12 @@ describe('transformStageMapNodesToTree', () => {
     const topologyNodes = [
       makeMockNode('rag_optimization__validate_inputs', 'Validate inputs'),
       makeMockNode('rag_optimization__optimize_templates', 'Optimize templates'),
-      makeMockNode('rag_optimization__step__chunking__branch-0', 'Chunking'),
+      makeMockNode('rag_optimization__step__chunking__branch-0', 'Chunk documents'),
       makeMockNode('rag_optimization__pattern__branch-0', 'Pattern 1'),
       makeMockNode('rag_optimization__run_optimization', 'Run optimization'),
       makeMockNode('rag_optimization2__validate_inputs', 'Validate inputs'),
       makeMockNode('rag_optimization2__optimize_templates', 'Optimize templates'),
-      makeMockNode('rag_optimization2__step__chunking__branch-0', 'Chunking'),
+      makeMockNode('rag_optimization2__step__chunking__branch-0', 'Chunk documents'),
       makeMockNode('rag_optimization2__pattern__branch-0', 'Pattern 2'),
       makeMockNode('rag_optimization2__run_optimization', 'Run optimization'),
     ];
@@ -261,7 +261,7 @@ describe('transformStageMapNodesToTree', () => {
     const topologyNodes = [
       makeMockNode('rag_optimization__validate_inputs', 'Validate inputs'),
       makeMockNode('rag_optimization__optimize_templates', 'Optimize templates'),
-      makeMockNode(invalidBranchId, 'Chunking'),
+      makeMockNode(invalidBranchId, 'Chunk documents'),
       makeMockNode('rag_optimization__run_optimization', 'Run optimization'),
     ];
 

--- a/packages/autorag/frontend/src/app/topology/tree-view/stepMetadata.ts
+++ b/packages/autorag/frontend/src/app/topology/tree-view/stepMetadata.ts
@@ -15,6 +15,8 @@ import {
 export type StepDetail = {
   label: string;
   value: string;
+  /** Optional popover help shown next to the label. */
+  help?: { header: string; body: string };
 };
 
 export type StepMetadata = {
@@ -35,18 +37,19 @@ const STAGE_DESCRIPTIONS: Record<string, string> = {
     'Listing the available documents and sampling a subset to build the evaluation set.',
   write_descriptor: 'Writing the document descriptor used to track downstream processing.',
   load_descriptor: 'Loading the document descriptor to resume processing.',
-  extract_documents: 'Extracting and parsing document content for indexing and evaluation.',
-  prepare_search_space:
-    'Preparing the search space of chunking, embedding, retrieval, and generation options to explore.',
+  load_benchmark: 'Loading the benchmark and metrics configuration.',
+  discover_documents: 'Scanning knowledge sources for documents.',
+  extract_documents: 'Extracting and normalizing document content.',
+  prepare_search_space: 'Chunking documents and indexing embeddings in the vector store.',
   write_report: 'Writing the evaluation report summarizing pipeline results.',
   optimize_templates:
-    'Evaluating candidate RAG pattern configurations and selecting the top performers to run in parallel.',
+    'Testing prompt templates across parallel branches. Branch steps will show as pending until all branches complete.',
   run_optimization:
     'Running each candidate pattern through the RAG pipeline and scoring its responses.',
   write_patterns: 'Writing the evaluated pattern configurations and their scores.',
   build_requests: 'Building the request payloads used to query the RAG pipeline for each pattern.',
   write_artifacts: 'Writing pattern artifacts such as notebooks and configuration files.',
-  build_leaderboard: 'Building the leaderboard and ranking patterns by their optimized metric.',
+  build_leaderboard: 'Selecting the best-performing pattern for deployment.',
 };
 
 const STEP_DESCRIPTIONS: Record<string, string> = {
@@ -54,9 +57,31 @@ const STEP_DESCRIPTIONS: Record<string, string> = {
   embedding: 'Generating vector embeddings for each chunk.',
   retrieval: 'Retrieving the most relevant chunks for a given query.',
   generation: 'Generating an answer from the retrieved context.',
-  evaluation: 'Evaluating the generated answer against the evaluation dataset.',
+  evaluation: 'Comprehensive evaluation of the final pattern using holdout test data.',
 };
 /* eslint-enable camelcase */
+
+const getCuratedDescription = (nodeId: string): string | undefined => {
+  const parsed = parseStageMapNodeId(nodeId);
+  if (parsed?.type === 'stage' && Object.hasOwn(STAGE_DESCRIPTIONS, parsed.stageId)) {
+    return STAGE_DESCRIPTIONS[parsed.stageId];
+  }
+  if (parsed?.type === 'branch_step' && Object.hasOwn(STEP_DESCRIPTIONS, parsed.stepId)) {
+    return STEP_DESCRIPTIONS[parsed.stepId];
+  }
+
+  const stepId = extractStepId(nodeId);
+  if (stepId && Object.hasOwn(STEP_DESCRIPTIONS, stepId)) {
+    return STEP_DESCRIPTIONS[stepId];
+  }
+
+  const stageId = extractStageId(nodeId);
+  if (stageId && Object.hasOwn(STAGE_DESCRIPTIONS, stageId)) {
+    return STAGE_DESCRIPTIONS[stageId];
+  }
+
+  return undefined;
+};
 
 const extractStageId = (nodeId: string): string | undefined => {
   const parts = nodeId.split('__');
@@ -140,9 +165,13 @@ export const getStepMetadata = (
     }
 
     const mapDetails = getStageMapDetails(parsed, componentStageMap, pipelineRun, label, stepState);
+    const curatedDescription = getCuratedDescription(nodeId);
     if (!mapDetails) {
       return {
-        description: getStageDescriptionFromMap(parsed, componentStageMap) ?? metadata.description,
+        description:
+          curatedDescription ??
+          getStageDescriptionFromMap(parsed, componentStageMap) ??
+          metadata.description,
         details: getDetailsFromPipelineRun(parsed.componentId, pipelineRun),
       };
     }
@@ -162,7 +191,7 @@ export const getStepMetadata = (
     }
 
     return {
-      description: mapDescription ?? metadata.description,
+      description: curatedDescription ?? mapDescription ?? metadata.description,
       details,
     };
   };
@@ -183,7 +212,7 @@ export const getStepMetadata = (
   if (stepId) {
     return resolveMetadata({
       description:
-        (Object.hasOwn(STEP_DESCRIPTIONS, stepId) ? STEP_DESCRIPTIONS[stepId] : undefined) ??
+        getCuratedDescription(nodeId) ??
         `Running ${resolveStepLabel(stepId)} for this pattern path.`,
       details: DEFAULT_DETAILS,
     });
@@ -199,9 +228,7 @@ export const getStepMetadata = (
   const stageId = extractStageId(nodeId);
   if (stageId) {
     return resolveMetadata({
-      description:
-        (Object.hasOwn(STAGE_DESCRIPTIONS, stageId) ? STAGE_DESCRIPTIONS[stageId] : undefined) ??
-        `Pipeline step: ${resolveStageLabel(stageId)}.`,
+      description: getCuratedDescription(nodeId) ?? `Pipeline step: ${resolveStageLabel(stageId)}.`,
       details: DEFAULT_DETAILS,
     });
   }

--- a/packages/autorag/frontend/src/app/types/autoragPattern.ts
+++ b/packages/autorag/frontend/src/app/types/autoragPattern.ts
@@ -78,7 +78,8 @@ export type AutoragPatternV1 = {
 export type AutoragVectorStoreBinding = {
   provider_id: string;
   provider_type: string;
-  vector_store_id: string;
+  /** Possibly null when the pipeline did not bind a collection */
+  vector_store_id: string | null;
 };
 
 export type AutoragEvaluationMetric = {

--- a/packages/cypress/cypress/utils/autoragTestFlows.ts
+++ b/packages/cypress/cypress/utils/autoragTestFlows.ts
@@ -108,6 +108,9 @@ export const configureAutoragRun = (
       { force: true },
     );
 
+  cy.step('Wait for evaluation file upload to complete');
+  autoragConfigurePage.findEvaluationFileValue().invoke('val').should('not.be.empty');
+
   cy.step('Select first available vector store');
   autoragConfigurePage.findVectorStoreSelector().should('not.be.disabled').click();
   autoragConfigurePage.findFirstVectorStoreOption().should('be.visible').click();

--- a/packages/cypress/cypress/utils/oc_commands/autoragInfra.ts
+++ b/packages/cypress/cypress/utils/oc_commands/autoragInfra.ts
@@ -276,18 +276,13 @@ const buildOgxConfig = (namespace: string): string => {
       ],
       inference: [
         {
-          provider_id: 'sentence-transformers',
-          provider_type: 'inline::sentence-transformers',
-          config: {},
-        },
-        {
           provider_id: 'vllm-inference-llm',
           provider_type: 'remote::vllm',
           config: {
             base_url: llmUrl,
             max_tokens: '${env.VLLM_MAX_TOKENS:=4096}',
-            api_token: '${env.VLLM_API_TOKEN_1:=fake}',
-            tls_verify: '${env.VLLM_TLS_VERIFY:=false}',
+            tls_verify: false,
+            refresh_models: false,
           },
         },
       ],
@@ -350,8 +345,8 @@ const buildOgxConfig = (namespace: string): string => {
     vector_stores: {
       default_provider_id: 'pgvector',
       default_embedding_model: {
-        provider_id: 'sentence-transformers',
-        model_id: 'all-MiniLM-L6-v2',
+        provider_id: 'vllm-inference-llm',
+        model_id: INLINE_EMBEDDING_MODEL_ID,
       },
     },
     registered_resources: {
@@ -365,7 +360,7 @@ const buildOgxConfig = (namespace: string): string => {
         },
         {
           model_id: INLINE_EMBEDDING_MODEL_ID,
-          provider_id: 'sentence-transformers',
+          provider_id: 'vllm-inference-llm',
           provider_model_id: INLINE_EMBEDDING_MODEL_ID,
           model_type: 'embedding',
           metadata: {


### PR DESCRIPTION
## Cherry-picked commits

- 7a5d9cffd fix(autox): desynchronized pipeline status and visualization (#8968) (#9003)
- f16d847c7 fix(autorag): fix eval file upload race and tolerate new OGX model types (#8932) (#9005)
- 57d8a3ccf fix(automl/autorag): update pipeline visualization content and drawer copy (#8980) (#9006)

## Summary

- **Pipeline status desync fix** — resolves race condition where pipeline visualization status would fall out of sync with actual run state
- **AutoRAG eval file upload race** — fixes race condition in eval file upload and adds tolerance for new OGX model types
- **Visualization content updates** — refreshes pipeline node labels (verb-first style), curated drawer descriptions, help popovers, and failure messaging for AutoML and AutoRAG

All three commits applied cleanly with no conflicts against `rhoai-3.5`.