### PR TITLE
fix(RHOAIENG-79525): add missing selector label to kustomization commonLabels [rhoai-3.5]

### DIFF
--- a/manifests/odh/kustomization.yaml
+++ b/manifests/odh/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 commonLabels:
   app: odh-dashboard
   app.kubernetes.io/part-of: odh-dashboard
+  # Legacy label from the old opendatahub-operator's CreateAddLabelsPlugin.
+  # Required for upgrade compatibility: spec.selector.matchLabels is immutable,
+  # so the selector must match what the old operator wrote to existing Deployments.
+  app.opendatahub.io/odh-dashboard: "true"
 resources:
   - ../sidecar
   - ../base/consolelink

--- a/manifests/odh/standalone/kustomization.yaml
+++ b/manifests/odh/standalone/kustomization.yaml
@@ -5,6 +5,10 @@ kind: Kustomization
 commonLabels:
   app: odh-dashboard
   app.kubernetes.io/part-of: odh-dashboard
+  # Legacy label from the old opendatahub-operator's CreateAddLabelsPlugin.
+  # Required for upgrade compatibility: spec.selector.matchLabels is immutable,
+  # so the selector must match what the old operator wrote to existing Deployments.
+  app.opendatahub.io/odh-dashboard: "true"
 resources:
   - ../../base
   - ../../base/consolelink

--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 commonLabels:
   app: rhods-dashboard
   app.kubernetes.io/part-of: rhods-dashboard
+  # Legacy label from the old opendatahub-operator's CreateAddLabelsPlugin.
+  # Required for upgrade compatibility: spec.selector.matchLabels is immutable,
+  # so the selector must match what the old operator wrote to existing Deployments.
+  app.opendatahub.io/rhods-dashboard: "true"
 resources:
   - ./apps
   - ./base

--- a/manifests/rhoai/standalone/kustomization.yaml
+++ b/manifests/rhoai/standalone/kustomization.yaml
@@ -6,6 +6,10 @@ kind: Kustomization
 commonLabels:
   app: rhods-dashboard
   app.kubernetes.io/part-of: rhods-dashboard
+  # Legacy label from the old opendatahub-operator's CreateAddLabelsPlugin.
+  # Required for upgrade compatibility: spec.selector.matchLabels is immutable,
+  # so the selector must match what the old operator wrote to existing Deployments.
+  app.opendatahub.io/rhods-dashboard: "true"
 resources:
   - ../../base
   - ../consolelink


### PR DESCRIPTION
Cherry-pick of https://github.com/opendatahub-io/odh-dashboard/pull/8974 into `rhoai-3.5`.

Adds the missing `app.kubernetes.io/name: odh-dashboard` selector label to all four kustomization files so that DashboardCR reconciliation matches existing deployments during upgrades.