### PR TITLE
Merge v3.5.0-fixes into rhoai-3.5

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -115,6 +115,19 @@ rules:
       - update
       - patch
       - delete
+  # PodDisruptionBudgets for core dashboard availability
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   # Networking
   - apiGroups:
       - networking.k8s.io

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -99,6 +99,19 @@ rules:
       - update
       - patch
       - delete
+  # PodDisruptionBudgets for core dashboard availability
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   # Networking
   - apiGroups:
       - networking.k8s.io

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -883,5 +884,6 @@ func SetupWithManager(mgr ctrl.Manager, opts Options) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Complete(r)
 }

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - kube-rbac-proxy-config.yaml
   - service.yaml
   - service-account.yaml
+  - pdb.yaml

--- a/manifests/base/pdb.yaml
+++ b/manifests/base/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: odh-dashboard
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      deployment: odh-dashboard

--- a/manifests/modules/agent-ops/deployment.yaml
+++ b/manifests/modules/agent-ops/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: agent-ops-ui
@@ -101,11 +101,12 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              cpu: 100m
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8843

--- a/manifests/modules/automl/deployment.yaml
+++ b/manifests/modules/automl/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: automl-ui
@@ -101,11 +101,12 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              cpu: 100m
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8643

--- a/manifests/modules/autorag/deployment.yaml
+++ b/manifests/modules/autorag/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: autorag-ui
@@ -101,11 +101,12 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              cpu: 100m
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8743

--- a/manifests/modules/eval-hub/deployment.yaml
+++ b/manifests/modules/eval-hub/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: eval-hub-ui
@@ -101,11 +101,12 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              cpu: 100m
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8543

--- a/manifests/modules/gen-ai/deployment.yaml
+++ b/manifests/modules/gen-ai/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: gen-ai-ui
@@ -101,11 +101,12 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              cpu: 100m
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8143

--- a/manifests/modules/maas/deployment.yaml
+++ b/manifests/modules/maas/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: maas-ui
@@ -101,11 +101,12 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              cpu: 100m
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8243

--- a/manifests/modules/mlflow/deployment.yaml
+++ b/manifests/modules/mlflow/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: mlflow-ui
@@ -101,11 +101,12 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              cpu: 100m
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8343

--- a/manifests/modules/model-registry/deployment.yaml
+++ b/manifests/modules/model-registry/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: model-registry-ui
@@ -101,11 +101,12 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              cpu: 100m
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8043

--- a/manifests/rhoai/base/kustomization.yaml
+++ b/manifests/rhoai/base/kustomization.yaml
@@ -73,5 +73,11 @@ patchesJson6902:
       version: v1
       kind: ClusterRoleBinding
       name: odh-dashboard-modules
+  - path: pdb.yaml
+    target:
+      group: policy
+      version: v1
+      kind: PodDisruptionBudget
+      name: odh-dashboard
 patchesStrategicMerge:
   - federation-configmap.yaml

--- a/manifests/rhoai/base/pdb.yaml
+++ b/manifests/rhoai/base/pdb.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/name
+  value: rhods-dashboard
+- op: replace
+  path: /spec/selector/matchLabels/deployment
+  value: rhods-dashboard

--- a/manifests/rhoai/standalone/kustomization.yaml
+++ b/manifests/rhoai/standalone/kustomization.yaml
@@ -134,6 +134,12 @@ patchesJson6902:
       name: odh-dashboard
   # NetworkPolicy only exists in manifests/sidecar/ — not present in ../../base.
   # No NetworkPolicy patch needed in standalone mode.
+  - path: pdb.yaml
+    target:
+      group: policy
+      version: v1
+      kind: PodDisruptionBudget
+      name: odh-dashboard
 replacements:
   - source:
       kind: ConfigMap

--- a/manifests/rhoai/standalone/pdb.yaml
+++ b/manifests/rhoai/standalone/pdb.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/name
+  value: rhods-dashboard
+- op: replace
+  path: /spec/selector/matchLabels/deployment
+  value: rhods-dashboard


### PR DESCRIPTION
## Summary
- Merge upstream `opendatahub-io:v3.5.0-fixes` into `rhoai-3.5`
- Brings in [RHOAIENG-79644](https://issues.redhat.com/browse/RHOAIENG-79644): Right-size standalone deployment resources and add PDB (#9027)

### Changes included
- **Module pods (all 8 modules):** Reduced replicas to 1, CPU request to 10m, memory request to 64Mi, memory limit to 192Mi, added CPU limit of 100m
- **PodDisruptionBudget:** Added `minAvailable: 1` for core dashboard deployment
- **Operator:** Added `Owns(&policyv1.PodDisruptionBudget{})` for re-reconciliation
- **Helm chart:** Synced PDB RBAC to chart ClusterRole