### PR TITLE
chore: add trustyai package to Konflux Dockerfiles

### DIFF
--- a/Dockerfile.konflux.agent-ops
+++ b/Dockerfile.konflux.agent-ops
@@ -34,6 +34,7 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/trustyai/ ./packages/trustyai/
 COPY --chown=default:root packages/model-registry/package.json ./packages/model-registry/
 COPY --chown=default:root packages/model-registry/shared/ ./packages/model-registry/shared/
 COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/

--- a/Dockerfile.konflux.automl
+++ b/Dockerfile.konflux.automl
@@ -34,6 +34,7 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/trustyai/ ./packages/trustyai/
 COPY --chown=default:root packages/model-registry/package.json ./packages/model-registry/
 COPY --chown=default:root packages/model-registry/shared/ ./packages/model-registry/shared/
 COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/

--- a/Dockerfile.konflux.autorag
+++ b/Dockerfile.konflux.autorag
@@ -34,6 +34,7 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/trustyai/ ./packages/trustyai/
 COPY --chown=default:root packages/model-registry/package.json ./packages/model-registry/
 COPY --chown=default:root packages/model-registry/shared/ ./packages/model-registry/shared/
 COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/

--- a/Dockerfile.konflux.eval-hub
+++ b/Dockerfile.konflux.eval-hub
@@ -34,6 +34,7 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/trustyai/ ./packages/trustyai/
 COPY --chown=default:root packages/model-registry/package.json ./packages/model-registry/
 COPY --chown=default:root packages/model-registry/shared/ ./packages/model-registry/shared/
 COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/

--- a/Dockerfile.konflux.genai
+++ b/Dockerfile.konflux.genai
@@ -34,6 +34,7 @@ COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/trustyai/ ./packages/trustyai/
 COPY --chown=default:root packages/model-registry/package.json ./packages/model-registry/
 COPY --chown=default:root packages/model-registry/shared/ ./packages/model-registry/shared/
 COPY --chown=default:root packages/hardware-profiles/ ./packages/hardware-profiles/

--- a/Dockerfile.konflux.maas
+++ b/Dockerfile.konflux.maas
@@ -38,6 +38,7 @@ COPY --chown=default:root packages/connection-types/ ./packages/connection-types
 # Copy packages required for @odh-dashboard/llmd-serving and its dependencies
 COPY --chown=default:root packages/llmd-serving/ ./packages/llmd-serving/
 COPY --chown=default:root packages/model-serving/ ./packages/model-serving/
+COPY --chown=default:root packages/trustyai/ ./packages/trustyai/
 COPY --chown=default:root packages/kserve/ ./packages/kserve/
 COPY --chown=default:root packages/model-registry/ ./packages/model-registry/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79876

## Description

Upstream PR opendatahub-io#9046 creates `packages/trustyai/` as a new workspace package for TrustyAI/explainability domain types. That PR updates the upstream `Dockerfile.workspace` files for all modules that transitively depend on `@odh-dashboard/trustyai` (via `model-serving`) to include `COPY packages/trustyai/`.

This PR mirrors that change in the downstream Konflux Dockerfiles (`Dockerfile.konflux.*`) for the same 6 modules, ensuring their container builds have the `packages/trustyai/` workspace package available at build time.

## Affected files

* `Dockerfile.konflux.agent-ops`
* `Dockerfile.konflux.automl`
* `Dockerfile.konflux.autorag`
* `Dockerfile.konflux.eval-hub`
* `Dockerfile.konflux.genai`
* `Dockerfile.konflux.maas`

## Test plan

* Verify Konflux builds pass for affected modules

Made with [Cursor](https://cursor.com)