### PR TITLE
fix: update broken Elastic Search Labs blog URL in elastic-app manifest

### DIFF
--- a/manifests/rhoai/shared/apps/elastic/elastic-app.yaml
+++ b/manifests/rhoai/shared/apps/elastic/elastic-app.yaml
@@ -49,7 +49,7 @@ spec:
 
     - Through features like chunking, [connectors](https://www.elastic.co/guide/en/enterprise-search/current/connectors.html), and web crawlers, Elastic ensures a seamless process for ingesting diverse datasets into the search 'layer'.
 
-    - Semantic search with ELSER - Elastic Learned Sparse EncodeR, the built-in machine learning model, and use the [E5 embedding model](https://www.elastic.co/search-labs/blog/articles/multilingual-vector-search-e5-embedding-model) for multilingual vector search.  These models, and others, address the need to ground LLMs, help prompt large language models like OpenAI, and pave the way for generative AI experiences.
+    - Semantic search with ELSER - Elastic Learned Sparse EncodeR, the built-in machine learning model, and use the [E5 embedding model](https://www.elastic.co/search-labs/blog/multilingual-vector-search-e5-embedding-model) for multilingual vector search.  These models, and others, address the need to ground LLMs, help prompt large language models like OpenAI, and pave the way for generative AI experiences.
 
     - Elastic's API-first approach is enhanced by the Elastic Open Inference API, which streamlines code and manages inference for developers, providing flexibility to change models. Whether you use the built-in ELSER model or integrate with embedding models from the ecosystem via Red Hat Openshift AI, Hugging Face, Cohere, OpenAI, or others for RAG workloads, a single, straightforward API call ensures clean code for managing hybrid inference deployment.
 


### PR DESCRIPTION
## Problem

Same issue as https://github.com/red-hat-data-services/odh-dashboard/pull/2289 (rhoai-3.3).

The Elastic Search Labs blog URL for the E5 multilingual vector search article returns 404, causing `testManifestLinks` Cypress test to fail.

**Broken URL:** `https://www.elastic.co/search-labs/blog/articles/multilingual-vector-search-e5-embedding-model` → 404
**Correct URL:** `https://www.elastic.co/search-labs/blog/multilingual-vector-search-e5-embedding-model`

## Changes

- `manifests/rhoai/shared/apps/elastic/elastic-app.yaml`: Updated the E5 embedding model blog URL