### PR TITLE
fix: update broken Elastic Search Labs blog URL in elastic-app manifest (#9112)

### DIFF
--- a/manifests/rhoai/shared/apps/elastic/elastic-app.yaml
+++ b/manifests/rhoai/shared/apps/elastic/elastic-app.yaml
@@ -49,7 +49,7 @@ spec:
 
     - Through features like chunking, [connectors](https://www.elastic.co/guide/en/enterprise-search/current/connectors.html), and web crawlers, Elastic ensures a seamless process for ingesting diverse datasets into the search 'layer'.
 
-    - Semantic search with ELSER - Elastic Learned Sparse EncodeR, the built-in machine learning model, and use the [E5 embedding model](https://www.elastic.co/search-labs/blog/articles/multilingual-vector-search-e5-embedding-model) for multilingual vector search.  These models, and others, address the need to ground LLMs, help prompt large language models like OpenAI, and pave the way for generative AI experiences.
+    - Semantic search with ELSER - Elastic Learned Sparse EncodeR, the built-in machine learning model, and use the [E5 embedding model](https://www.elastic.co/search-labs/blog/multilingual-vector-search-e5-embedding-model) for multilingual vector search.  These models, and others, address the need to ground LLMs, help prompt large language models like OpenAI, and pave the way for generative AI experiences.
 
     - Elastic's API-first approach is enhanced by the Elastic Open Inference API, which streamlines code and manages inference for developers, providing flexibility to change models. Whether you use the built-in ELSER model or integrate with embedding models from the ecosystem via Red Hat Openshift AI, Hugging Face, Cohere, OpenAI, or others for RAG workloads, a single, straightforward API call ensures clean code for managing hybrid inference deployment.
 


### PR DESCRIPTION
The Elastic blog URL for the E5 multilingual vector search article moved from /blog/articles/ to /blog/ path, causing manifest URL validation tests to fail with 404.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
