### PR TITLE
[rhoai-3.5] Merge v3.5.0-fixes

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -375,6 +375,16 @@ rules:
       - update
       - patch
       - delete
+  # system:image-puller (referenced by the cluster-image-pullers
+  # RoleBinding) grants imagestreams/layers get under both "" and
+  # image.openshift.io. RBAC escalation prevention requires the
+  # operator SA to hold the core-group variant as well.
+  - apiGroups:
+      - ""
+    resources:
+      - imagestreams/layers
+    verbs:
+      - get
   # Verbs cover both sa-rbac/role.yaml (list) and
   # fetch-builds-and-images.rbac.yaml (get, list, watch).
   - apiGroups:

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -359,6 +359,16 @@ rules:
       - update
       - patch
       - delete
+  # system:image-puller (referenced by the cluster-image-pullers
+  # RoleBinding) grants imagestreams/layers get under both "" and
+  # image.openshift.io. RBAC escalation prevention requires the
+  # operator SA to hold the core-group variant as well.
+  - apiGroups:
+      - ""
+    resources:
+      - imagestreams/layers
+    verbs:
+      - get
   # Verbs cover both sa-rbac/role.yaml (list) and
   # fetch-builds-and-images.rbac.yaml (get, list, watch).
   - apiGroups:


### PR DESCRIPTION
Merge `opendatahub-io/odh-dashboard:v3.5.0-fixes` into `red-hat-data-services/odh-dashboard:rhoai-3.5`.

Includes:
- fix(RHOAIENG-80801): add core apiGroup to imagestreams/layers escalation permission (#9093)
  - https://issues.redhat.com/browse/RHOAIENG-80801