### PR TITLE
fix(gen-ai): add egress rule for NemoGuardrails port 8443 in network policy - RHOAIENG-81990

### DIFF
--- a/manifests/modules/gen-ai/networkpolicy.yaml
+++ b/manifests/modules/gen-ai/networkpolicy.yaml
@@ -46,6 +46,8 @@ spec:
       ports:
         - port: 8321
           protocol: TCP
+        - port: 8443
+          protocol: TCP
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/RHOAIENG-81990
Original PR: https://github.com/opendatahub-io/odh-dashboard/pull/9151

Cherry-picking fix into rhoai-3.5. See original PR and issue for details:
