### PR TITLE
chore: sync Dockerfile.konflux.autorag/automl BFF stage with autox-core extraction

### DIFF
--- a/Dockerfile.konflux.automl
+++ b/Dockerfile.konflux.automl
@@ -88,7 +88,8 @@ COPY ${BFF_SOURCE_CODE}/cmd/ cmd/
 COPY ${BFF_SOURCE_CODE}/internal/ internal/
 
 # Build the Go application
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/bff ./cmd
+RUN CGO_ENABLED=1 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
+    go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/bff ./cmd
 
 # Final stage
 FROM ${DISTROLESS_BASE_IMAGE}

--- a/Dockerfile.konflux.automl
+++ b/Dockerfile.konflux.automl
@@ -69,20 +69,26 @@ ARG BFF_SOURCE_CODE
 ARG TARGETOS
 ARG TARGETARCH
 
-WORKDIR /usr/src/app
+# Layout mirrors the monorepo so the go.mod replace directive
+# (../../autox-core/services) resolves correctly inside the container.
 
-# Copy the Go Modules manifests
-COPY ${BFF_SOURCE_CODE}/go.mod ${BFF_SOURCE_CODE}/go.sum ./
+WORKDIR /usr/src/workspace
+
+# Copy module manifests first for dependency caching
+COPY packages/autox-core/services/go.mod packages/autox-core/services/go.sum ./packages/autox-core/services/
+COPY ${BFF_SOURCE_CODE}/go.mod ${BFF_SOURCE_CODE}/go.sum ./${BFF_SOURCE_CODE}/
 
 # Download dependencies
+WORKDIR /usr/src/workspace/${BFF_SOURCE_CODE}
 RUN go mod download
 
-# Copy the go source files
+# Copy source files
+COPY packages/autox-core/services/ /usr/src/workspace/packages/autox-core/services/
 COPY ${BFF_SOURCE_CODE}/cmd/ cmd/
 COPY ${BFF_SOURCE_CODE}/internal/ internal/
 
 # Build the Go application
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o bff ./cmd
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/bff ./cmd
 
 # Final stage
 FROM ${DISTROLESS_BASE_IMAGE}
@@ -90,7 +96,7 @@ FROM ${DISTROLESS_BASE_IMAGE}
 ARG UI_SOURCE_CODE
 
 WORKDIR /
-COPY --from=bff-builder /usr/src/app/bff ./
+COPY --from=bff-builder /tmp/bff ./
 COPY --from=ui-builder /usr/src/workspace/${UI_SOURCE_CODE}/dist ./static/
 USER 65532:65532
 

--- a/Dockerfile.konflux.autorag
+++ b/Dockerfile.konflux.autorag
@@ -88,7 +88,8 @@ COPY ${BFF_SOURCE_CODE}/cmd/ cmd/
 COPY ${BFF_SOURCE_CODE}/internal/ internal/
 
 # Build the Go application
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/bff ./cmd
+RUN CGO_ENABLED=1 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
+    go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/bff ./cmd
 
 # Final stage
 FROM ${DISTROLESS_BASE_IMAGE}

--- a/Dockerfile.konflux.autorag
+++ b/Dockerfile.konflux.autorag
@@ -69,20 +69,26 @@ ARG BFF_SOURCE_CODE
 ARG TARGETOS
 ARG TARGETARCH
 
-WORKDIR /usr/src/app
+# Layout mirrors the monorepo so the go.mod replace directive
+# (../../autox-core/services) resolves correctly inside the container.
 
-# Copy the Go Modules manifests
-COPY ${BFF_SOURCE_CODE}/go.mod ${BFF_SOURCE_CODE}/go.sum ./
+WORKDIR /usr/src/workspace
+
+# Copy module manifests first for dependency caching
+COPY packages/autox-core/services/go.mod packages/autox-core/services/go.sum ./packages/autox-core/services/
+COPY ${BFF_SOURCE_CODE}/go.mod ${BFF_SOURCE_CODE}/go.sum ./${BFF_SOURCE_CODE}/
 
 # Download dependencies
+WORKDIR /usr/src/workspace/${BFF_SOURCE_CODE}
 RUN go mod download
 
-# Copy the go source files
+# Copy source files
+COPY packages/autox-core/services/ /usr/src/workspace/packages/autox-core/services/
 COPY ${BFF_SOURCE_CODE}/cmd/ cmd/
 COPY ${BFF_SOURCE_CODE}/internal/ internal/
 
 # Build the Go application
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o bff ./cmd
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/bff ./cmd
 
 # Final stage
 FROM ${DISTROLESS_BASE_IMAGE}
@@ -90,7 +96,7 @@ FROM ${DISTROLESS_BASE_IMAGE}
 ARG UI_SOURCE_CODE
 
 WORKDIR /
-COPY --from=bff-builder /usr/src/app/bff ./
+COPY --from=bff-builder /tmp/bff ./
 COPY --from=ui-builder /usr/src/workspace/${UI_SOURCE_CODE}/dist ./static/
 USER 65532:65532
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-82098

## Summary
- The BFF build stage in `Dockerfile.konflux.autorag` and `Dockerfile.konflux.automl` still used the pre-`autox-core/services` flat layout (`WORKDIR /usr/src/app`), so it never copied `packages/autox-core/services` into the build context.
- This meant the `go.mod` `replace` directive (`../../autox-core/services`) could not resolve during `go mod download`, unlike the upstream `Dockerfile.workspace` files which already mirror the monorepo layout.
- Updates both downstream Dockerfiles to mirror `Dockerfile.workspace`'s BFF stage: `WORKDIR /usr/src/workspace/<module>/bff`, copy `packages/autox-core/services/` before `go mod download`, and build to `/tmp/bff`.
- Pinned base image digests and the Red Hat `LABEL` blocks are untouched.
- Companion upstream PR that introduced `autox-core/services`: https://github.com/opendatahub-io/odh-dashboard/pull/7516

## Test plan
- [x] Verify Konflux build succeeds for both `odh-mod-arch-autorag` and `odh-mod-arch-automl` images