### PR TITLE
[rhoai-3.5] fix(RHOAIENG-82319): increase dashboard-operator memory limits to prevent OOMKilled

### DIFF
--- a/dashboard-operator/charts/dashboard/values.yaml
+++ b/dashboard-operator/charts/dashboard/values.yaml
@@ -30,10 +30,10 @@ manager:
   resources:
     limits:
       cpu: 500m
-      memory: 128Mi
+      memory: 256Mi
     requests:
       cpu: 10m
-      memory: 64Mi
+      memory: 192Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/dashboard-operator/config/manager/manager.yaml
+++ b/dashboard-operator/config/manager/manager.yaml
@@ -77,10 +77,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 128Mi
+              memory: 256Mi
             requests:
               cpu: 10m
-              memory: 64Mi
+              memory: 192Mi
       volumes:
         - name: webhook-certs
           secret:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-82319
https://issues.redhat.com/browse/RHOAIENG-82400

## Description

Cherry-pick merge of `opendatahub-io/odh-dashboard:v3.5.0-fixes` into `red-hat-data-services/odh-dashboard:rhoai-3.5`.

**Upstream PRs:**
- https://github.com/opendatahub-io/odh-dashboard/pull/9204 (main)
- https://github.com/opendatahub-io/odh-dashboard/pull/9234 (v3.5.0-fixes)

The dashboard-operator pod OOM-kills (exit code 137, CrashLoopBackOff) on **3.4→3.5 upgrade clusters** because its memory limit is set to **128Mi**. The operator's measured steady-state usage is **165Mi** on upgrade clusters, exceeding the limit.

Changes:
- `memory.requests`: 64Mi → **192Mi**
- `memory.limits`: 128Mi → **256Mi**

Updated in both `dashboard-operator/config/manager/manager.yaml` and `dashboard-operator/charts/dashboard/values.yaml`.