### PR TITLE
fix: use pull_request_target for gatekeeper to support fork PRs

### DIFF
--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -1,7 +1,7 @@
 name: Post-Codefreeze Gatekeeper
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited, labeled]
     branches:
       - 'rhoai-3.5'


### PR DESCRIPTION
## Summary

- `pull_request` events from fork PRs don't have access to the target repo's secrets — this is a GitHub security restriction
- The gatekeeper workflow fails on fork PRs (e.g. #2362) with: `Secret JIRA_USER_EMAIL is required, but not provided`
- Switching to `pull_request_target` runs the workflow from the base branch with full secret access
- This is safe because the [reusable workflow](https://github.com/red-hat-data-services/devops-shared-resources/blob/main/.github/workflows/post-codefreeze-gate-logic.yml) only checks out `devops-shared-resources` (never fork code) and only reads PR metadata to validate Jira issues

## Test plan

- [ ] Verify the gatekeeper check passes on #2362 (fork PR from `opendatahub-io`) after this merges
- [ ] Verify the gatekeeper still works on same-repo PRs

https://redhat.atlassian.net/browse/RHOAIENG-82298