### PR TITLE
feat: add post-codefreeze gatekeeper workflow to main

### DIFF
--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -1,0 +1,12 @@
+name: Post-Codefreeze Gatekeeper
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, labeled]
+    branches:
+      - 'rhoai-3.5'
+jobs:
+  post-codefreeze-gate:
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-gatekeeper'
+    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Copies the post-codefreeze gatekeeper workflow from `rhoai-3.5` to `main` so it's available when new release branches are cut
- Uses `pull_request_target` (not `pull_request`) to ensure repo secrets (Jira credentials) are accessible for both same-repo and fork PRs
- Already active on `rhoai-3.5` via #2363

## Test plan

- [x] Verified working on `rhoai-3.5` (#2363)
- [ ] Workflow will activate when a new `rhoai-*` branch is cut from main