### PR TITLE
Cherry-pick Glasswing rhoai-3.4 fixes to rhoai-3.5

### DIFF
--- a/backend/src/routes/api/rolebindings/index.ts
+++ b/backend/src/routes/api/rolebindings/index.ts
@@ -1,7 +1,7 @@
 import { KubeFastifyInstance } from '../../../types';
 import { FastifyReply, FastifyRequest } from 'fastify';
-import { V1RoleBinding } from '@kubernetes/client-node';
 import { secureRoute } from '../../../utils/route-security';
+import { getNamespaces } from '../../../utils/notebookUtils';
 
 module.exports = async (fastify: KubeFastifyInstance) => {
   fastify.get(
@@ -34,30 +34,49 @@ module.exports = async (fastify: KubeFastifyInstance) => {
 
   fastify.post(
     '/',
-    secureRoute(fastify)(
-      async (request: FastifyRequest<{ Body: V1RoleBinding }>, reply: FastifyReply) => {
-        const rbRequest = request.body;
-        try {
-          const response = await fastify.kube.customObjectsApi.createNamespacedCustomObject(
-            'rbac.authorization.k8s.io',
-            'v1',
-            rbRequest.metadata.namespace,
-            'rolebindings',
-            rbRequest,
-          );
-          return response.body;
-        } catch (e) {
-          if (e.response?.statusCode === 409) {
-            fastify.log.warn(`Rolebinding already present, skipping creation.`);
-            return {};
-          }
-
-          fastify.log.error(
-            `rolebinding could not be created: ${e.response?.body?.message || e.message}`,
-          );
-          reply.send(new Error(e.response?.body?.message));
+    secureRoute(fastify)(async (_request: FastifyRequest, reply: FastifyReply) => {
+      const { workbenchNamespace, dashboardNamespace } = getNamespaces(fastify);
+      const roleBindingName = `${workbenchNamespace}-image-pullers`;
+      const roleBindingObject = {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'RoleBinding',
+        metadata: {
+          name: roleBindingName,
+          namespace: dashboardNamespace,
+        },
+        roleRef: {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'ClusterRole',
+          name: 'system:image-puller',
+        },
+        subjects: [
+          {
+            apiGroup: 'rbac.authorization.k8s.io',
+            kind: 'Group',
+            name: `system:serviceaccounts:${workbenchNamespace}`,
+          },
+        ],
+      };
+      try {
+        const response = await fastify.kube.customObjectsApi.createNamespacedCustomObject(
+          'rbac.authorization.k8s.io',
+          'v1',
+          dashboardNamespace,
+          'rolebindings',
+          roleBindingObject,
+        );
+        return response.body;
+      } catch (e) {
+        if (e.response?.statusCode === 409) {
+          fastify.log.warn(`Rolebinding already present, skipping creation.`);
+          return {};
         }
-      },
-    ),
+
+        fastify.log.error(
+          `rolebinding could not be created: ${e.response?.body?.message || e.message}`,
+        );
+        reply.send(new Error(e.response?.body?.message));
+      }
+    }),
   );
 };

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -100,7 +100,7 @@ spec:
             - --auth-header-user-field-name=X-Auth-Request-User
             - --auth-header-groups-field-name=X-Auth-Request-Groups
             - --proxy-endpoints-port=8444
-            - --v=10
+            - --v=0
           image: $(kube-rbac-proxy)
           ports:
             - containerPort: 8443

--- a/manifests/base/sa-rbac/cluster-role.yaml
+++ b/manifests/base/sa-rbac/cluster-role.yaml
@@ -43,20 +43,6 @@ rules:
       - imagestreams/layers
     verbs:
       - get
-  - apiGroups:
-      - ''
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    resources:
-      - configmaps
-      - persistentvolumeclaims
-      - secrets
   - verbs:
       - get
       - list
@@ -123,7 +109,7 @@ rules:
       - namespaces
   - apiGroups:
       - rbac.authorization.k8s.io
-      # The rbac.authorization.k8s.io permissions (list, get, create, patch, and delete on rolebindings, clusterrolebindings, and roles) are needed so the dashboard can handle user access and permissions automatically.
+      # The rbac.authorization.k8s.io permissions (list, get, create, patch, and delete on rolebindings and roles) are needed so the dashboard can handle user access and permissions automatically.
       # This includes tasks like assigning roles, updating existing bindings, and creating or removing access rules.
       # Ex. the standalone Jupyter workbench requires the ability to create an image puller role if one doesn't exist.
     verbs:
@@ -134,7 +120,6 @@ rules:
       - delete
     resources:
       - rolebindings
-      - clusterrolebindings
       - roles
   - apiGroups:
       - ''

--- a/manifests/base/sa-rbac/cluster-role.yaml
+++ b/manifests/base/sa-rbac/cluster-role.yaml
@@ -206,6 +206,13 @@ rules:
     resources:
       - featurestores
   - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - mlflow.opendatahub.io
     verbs:
       - get

--- a/manifests/base/sa-rbac/cluster-role.yaml
+++ b/manifests/base/sa-rbac/cluster-role.yaml
@@ -4,13 +4,6 @@ metadata:
   name: odh-dashboard
 rules:
   - verbs:
-      - update
-      - patch
-    apiGroups:
-      - storage.k8s.io
-    resources:
-      - storageclasses
-  - verbs:
       - get
       - list
     apiGroups:

--- a/manifests/base/sa-rbac/role.yaml
+++ b/manifests/base/sa-rbac/role.yaml
@@ -149,3 +149,22 @@ rules:
       - delete
     resources:
       - accounts
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - update


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-83240

## Description 

Backports the embargoed security/hardening fixes that landed on the private GitLab `rhoai-3.4` branch to GitHub `rhoai-3.5`, so 3.5 doesn't regress relative to 3.4 on these issues. `rhoai-3.5` had diverged from `rhoai-3.4` significantly (dependency bumps, feature work, e2e fixes, etc.), so instead of merging full branch history, the individual embargo merge commits were identified from GitLab `rhoai-3.4` and cherry-picked (`git cherry-pick -m 1`) onto this branch.

## How Has This Been Tested?

Not yet manually tested or run through lint/type-check/tests on this branch — cherry-picks applied cleanly with no conflicts, but verification is still pending.

## Test Impact

No new tests added; these are cherry-picked security/hardening fixes carried over from `rhoai-3.4`. Existing coverage for the touched RBAC manifests, backend auth handling, and container config is expected to apply as-is.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`