### PR TITLE
Add 127. localhost to the excluded strings like 3.5 (#9338)

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/dashboardNavigation/testManifestLinks.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/dashboardNavigation/testManifestLinks.yaml
@@ -17,6 +17,7 @@ excludedSubstrings:
   - project-simple
   - example.apps
   - localhost
+  - 127.0.0.1
   - console-openshift-console.apps.test-cluster.example.com/
   - console-openshift-console.apps.test-cluster.example.com
   - figma.com/figma/ns


### PR DESCRIPTION
3.4.4 blocker fix: https://redhat.atlassian.net/browse/RHOAIENG-84481

