### PR TITLE
fix: bump Konflux Dockerfiles go-toolset 1.24 → 1.25 for Go CVE fixes (3.3)

### DIFF
--- a/Dockerfile.konflux.genai
+++ b/Dockerfile.konflux.genai
@@ -8,8 +8,8 @@ ARG UI_SOURCE_CODE=./packages/${MODULE_NAME}/frontend
 ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/bff
 
 # Set the base images for the build stages
-ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22@sha256:7a3cb98154245affe6d10f283912ae7f845f9fecd0b52aa1bfbbf5c200be282b
-ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22@sha256:0333accfa310d8575ca3e7ce130fcd7b14eb9f471dcfa23155e2d0e3caf045b3
+ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e
 ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
 
 # UI build stage

--- a/Dockerfile.konflux.maas
+++ b/Dockerfile.konflux.maas
@@ -8,8 +8,8 @@ ARG UI_SOURCE_CODE=./packages/${MODULE_NAME}/frontend
 ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/bff
 
 # Set the base images for the build stages
-ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22@sha256:7a3cb98154245affe6d10f283912ae7f845f9fecd0b52aa1bfbbf5c200be282b
-ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22@sha256:0333accfa310d8575ca3e7ce130fcd7b14eb9f471dcfa23155e2d0e3caf045b3
+ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e
 ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
 
 # UI build stage

--- a/Dockerfile.konflux.modelregistry
+++ b/Dockerfile.konflux.modelregistry
@@ -8,8 +8,8 @@ ARG UI_SOURCE_CODE=./packages/${MODULE_NAME}/upstream/frontend
 ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/upstream/bff
 
 # Set the base images for the build stages
-ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22@sha256:7a3cb98154245affe6d10f283912ae7f845f9fecd0b52aa1bfbbf5c200be282b
-ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22@sha256:0333accfa310d8575ca3e7ce130fcd7b14eb9f471dcfa23155e2d0e3caf045b3
+ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e
 ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
 
 # UI build stage


### PR DESCRIPTION
## Summary

Bumps GOLANG_BASE_IMAGE from go-toolset:1.24 to go-toolset:1.25 in 3 Konflux Dockerfiles for Go CVE fixes on rhoai-3.3.

### Files updated
- Dockerfile.konflux.genai
- Dockerfile.konflux.maas
- Dockerfile.konflux.modelregistry

### CVEs addressed (via upstream PR opendatahub-io/odh-dashboard#9349)
- CVE-2026-32283, 33814, 33811, 39820, 42499 (Go stdlib)
- CVE-2026-39821 (golang.org/x/net/idna)

Backport of downstream PR #2165 (rhoai-3.4).