### PR TITLE
fix(e2e): scroll catalog sidebar filters into view (#9353)

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/dashboardNavigation/testManifestLinks.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/dashboardNavigation/testManifestLinks.yaml
@@ -28,3 +28,6 @@ excludedSubstrings:
   - www3.
   - w3.org
   - serif.com
+  # Slack's edge/WAF intermittently 403s automated (non-browser) requests to this
+  # URL regardless of headers sent; the link itself works fine for real users.
+  - elasticstack.slack.com

--- a/packages/cypress/cypress/tests/e2e/modelCatalog/testPerformanceFiltersAvailable.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelCatalog/testPerformanceFiltersAvailable.cy.ts
@@ -113,8 +113,8 @@ describe('Verify Performance Filters are available on RHOAI', () => {
       modelCatalog.findColdStartLoadTimeFilter().should('be.visible');
 
       cy.step('Verify performance sidebar slider filters appear');
-      modelCatalog.findMinimumVramFilter().should('be.visible');
-      modelCatalog.findContainerSizeFilter().should('be.visible');
+      modelCatalog.findMinimumVramFilter().scrollIntoView().should('be.visible');
+      modelCatalog.findContainerSizeFilter().scrollIntoView().should('be.visible');
 
       cy.step('Check if performance data is available on this cluster');
       checkPerformanceDataAvailable(15000).then((count) => {


### PR DESCRIPTION
Tool-calling is on by default, so Validated arguments pushes container size below the fixed sidebar fold and Cypress visibility assertions time out.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
