### PR TITLE
Merge upstream v3.5.0-fixes into rhoai-3.5

### DIFF
--- a/dashboard-operator/internal/controller/actions.go
+++ b/dashboard-operator/internal/controller/actions.go
@@ -10,8 +10,11 @@ import (
 	"strings"
 
 	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -37,6 +40,57 @@ const (
 	dataScienceGatewayNamespace   = "openshift-ingress"
 	rayDataScienceGatewayRBACName = "fetch-ray-data-science-gateway"
 )
+
+const (
+	persesServiceName              = "data-science-perses"
+	persesServicePort        int32 = 8080
+	rhoaiMonitoringNamespace       = "redhat-ods-monitoring"
+)
+
+func (r *DashboardReconciler) monitoringNamespace() string {
+	switch r.Platform {
+	case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
+		return rhoaiMonitoringNamespace
+	default:
+		return r.ApplicationsNamespace
+	}
+}
+
+// autoDetectObservability populates spec.observability in-memory when the Perses
+// service exists but the CR has no explicit observability config. This bridges
+// 3.5GA until the ODH Operator projects the config via BuildModuleCR (3.6ea1).
+func (r *DashboardReconciler) autoDetectObservability(ctx context.Context, dashboard *v1alpha1.Dashboard) error {
+	if dashboard.Spec.Observability != nil {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	monitoringNS := r.monitoringNamespace()
+
+	svc := &corev1.Service{}
+	key := types.NamespacedName{Name: persesServiceName, Namespace: monitoringNS}
+	if err := r.Get(ctx, key, svc); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("looking up Perses service %s/%s: %w", monitoringNS, persesServiceName, err)
+	}
+
+	logger.Info("Auto-detected Perses service, enabling observability",
+		"service", persesServiceName, "namespace", monitoringNS)
+
+	dashboard.Spec.Observability = &v1alpha1.ObservabilitySpec{
+		Enabled: true,
+		PersesService: &v1alpha1.ServiceTarget{
+			Name:      persesServiceName,
+			Namespace: monitoringNS,
+			Port:      persesServicePort,
+		},
+	}
+
+	return nil
+}
 
 // remapRayDashboardGatewayRBAC moves the named Gateway Role/RoleBinding into
 // openshift-ingress so authenticated users can get data-science-gateway there.

--- a/dashboard-operator/internal/controller/actions_test.go
+++ b/dashboard-operator/internal/controller/actions_test.go
@@ -9,10 +9,13 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
@@ -317,4 +320,200 @@ func TestRemapRayDashboardGatewayRBAC(t *testing.T) {
 	assert.Equal(t, dataScienceGatewayNamespace, resources[0].GetNamespace())
 	assert.Equal(t, dataScienceGatewayNamespace, resources[1].GetNamespace())
 	assert.Equal(t, "opendatahub", resources[2].GetNamespace())
+}
+
+func TestMonitoringNamespace(t *testing.T) {
+	tests := []struct {
+		name                  string
+		platform              cluster.Platform
+		applicationsNamespace string
+		want                  string
+	}{
+		{
+			name:                  "SelfManagedRhoai returns hardcoded monitoring namespace",
+			platform:              cluster.SelfManagedRhoai,
+			applicationsNamespace: "redhat-ods-applications",
+			want:                  "redhat-ods-monitoring",
+		},
+		{
+			name:                  "ManagedRhoai returns hardcoded monitoring namespace",
+			platform:              cluster.ManagedRhoai,
+			applicationsNamespace: "redhat-ods-applications",
+			want:                  "redhat-ods-monitoring",
+		},
+		{
+			name:                  "OpenDataHub returns applications namespace",
+			platform:              cluster.OpenDataHub,
+			applicationsNamespace: "opendatahub",
+			want:                  "opendatahub",
+		},
+		{
+			name:                  "XKS returns applications namespace",
+			platform:              cluster.XKS,
+			applicationsNamespace: "my-namespace",
+			want:                  "my-namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &DashboardReconciler{
+				Platform:              tt.platform,
+				ApplicationsNamespace: tt.applicationsNamespace,
+			}
+			assert.Equal(t, tt.want, r.monitoringNamespace())
+		})
+	}
+}
+
+func TestAutoDetectObservability(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	persesService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      persesServiceName,
+			Namespace: "redhat-ods-monitoring",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 8080}},
+		},
+	}
+
+	persesServiceODH := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      persesServiceName,
+			Namespace: "opendatahub",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 8080}},
+		},
+	}
+
+	tests := []struct {
+		name                  string
+		platform              cluster.Platform
+		applicationsNamespace string
+		existingObs           *v1alpha1.ObservabilitySpec
+		objects               []runtime.Object
+		wantObs               *v1alpha1.ObservabilitySpec
+		wantErr               bool
+	}{
+		{
+			name:                  "explicit config present — no change",
+			platform:              cluster.SelfManagedRhoai,
+			applicationsNamespace: "redhat-ods-applications",
+			existingObs: &v1alpha1.ObservabilitySpec{
+				Enabled: true,
+				PersesService: &v1alpha1.ServiceTarget{
+					Name:      "custom-perses",
+					Namespace: "custom-ns",
+					Port:      9090,
+				},
+			},
+			objects: []runtime.Object{persesService},
+			wantObs: &v1alpha1.ObservabilitySpec{
+				Enabled: true,
+				PersesService: &v1alpha1.ServiceTarget{
+					Name:      "custom-perses",
+					Namespace: "custom-ns",
+					Port:      9090,
+				},
+			},
+		},
+		{
+			name:                  "service found RHOAI — populates observability",
+			platform:              cluster.SelfManagedRhoai,
+			applicationsNamespace: "redhat-ods-applications",
+			objects:               []runtime.Object{persesService},
+			wantObs: &v1alpha1.ObservabilitySpec{
+				Enabled: true,
+				PersesService: &v1alpha1.ServiceTarget{
+					Name:      persesServiceName,
+					Namespace: "redhat-ods-monitoring",
+					Port:      persesServicePort,
+				},
+			},
+		},
+		{
+			name:                  "service found ODH — populates with applications namespace",
+			platform:              cluster.OpenDataHub,
+			applicationsNamespace: "opendatahub",
+			objects:               []runtime.Object{persesServiceODH},
+			wantObs: &v1alpha1.ObservabilitySpec{
+				Enabled: true,
+				PersesService: &v1alpha1.ServiceTarget{
+					Name:      persesServiceName,
+					Namespace: "opendatahub",
+					Port:      persesServicePort,
+				},
+			},
+		},
+		{
+			name:                  "service not found — observability remains nil",
+			platform:              cluster.SelfManagedRhoai,
+			applicationsNamespace: "redhat-ods-applications",
+			objects:               nil,
+			wantObs:               nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+
+			r := &DashboardReconciler{
+				Client:                cli,
+				Platform:              tt.platform,
+				ApplicationsNamespace: tt.applicationsNamespace,
+			}
+
+			dashboard := &v1alpha1.Dashboard{
+				Spec: v1alpha1.DashboardSpec{
+					Observability: tt.existingObs,
+				},
+			}
+
+			err := r.autoDetectObservability(context.Background(), dashboard)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantObs, dashboard.Spec.Observability)
+		})
+	}
+}
+
+func TestAutoDetectObservability_NonNotFoundError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	injectedErr := assert.AnError
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				return injectedErr
+			},
+		}).
+		Build()
+
+	r := &DashboardReconciler{
+		Client:                cli,
+		Platform:              cluster.SelfManagedRhoai,
+		ApplicationsNamespace: "redhat-ods-applications",
+	}
+
+	dashboard := &v1alpha1.Dashboard{}
+	err := r.autoDetectObservability(context.Background(), dashboard)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, injectedErr)
+	assert.Nil(t, dashboard.Spec.Observability)
 }

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -222,17 +222,32 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return result, err
 }
 
+const observabilityRetryInterval = 5 * time.Minute
+
 func (r *DashboardReconciler) reconcile(
 	ctx context.Context,
 	dashboard *v1alpha1.Dashboard,
 	cm *conditions.Manager,
 	cfg OperatorConfig,
 ) (ctrl.Result, error) {
-	mode := dashboard.Spec.DeploymentMode
-	if mode == "" || mode == v1alpha1.DeploymentModeSidecar {
-		return r.reconcileSidecar(ctx, dashboard, cm, cfg)
+	if err := r.autoDetectObservability(ctx, dashboard); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to auto-detect observability, continuing without it")
 	}
-	return r.reconcileStandalone(ctx, dashboard, cm, cfg)
+
+	mode := dashboard.Spec.DeploymentMode
+	var result ctrl.Result
+	var err error
+	if mode == "" || mode == v1alpha1.DeploymentModeSidecar {
+		result, err = r.reconcileSidecar(ctx, dashboard, cm, cfg)
+	} else {
+		result, err = r.reconcileStandalone(ctx, dashboard, cm, cfg)
+	}
+
+	if dashboard.Spec.Observability == nil && err == nil && result.RequeueAfter == 0 {
+		result.RequeueAfter = observabilityRetryInterval
+	}
+
+	return result, err
 }
 
 func (r *DashboardReconciler) reconcileSidecar(
@@ -635,6 +650,10 @@ func (r *DashboardReconciler) cleanupCrossNamespaceResources(ctx context.Context
 	if dashboard.Spec.Observability != nil &&
 		dashboard.Spec.Observability.PersesService != nil {
 		obsNS = dashboard.Spec.Observability.PersesService.Namespace
+	}
+
+	if obsNS == "" {
+		obsNS = r.monitoringNamespace()
 	}
 
 	if obsNS == "" || obsNS == r.ApplicationsNamespace {

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -148,6 +148,7 @@ func TestReconcile(t *testing.T) {
 			wantProvisioned: boolPtr(true),
 			wantURL:         "https://dashboard.apps.example.com",
 			wantGeneration:  3,
+			wantRequeue:     ctrlpkg.ObservabilityRetryInterval,
 		},
 		{
 			name:       "kustomize failure",
@@ -200,6 +201,7 @@ func TestReconcile(t *testing.T) {
 			wantProvisioned: boolPtr(true),
 			wantURL:         "https://dashboard.apps.example.com",
 			wantGeneration:  1,
+			wantRequeue:     ctrlpkg.ObservabilityRetryInterval,
 			wantModuleCount: registrySize,
 			wantModulePhases: map[string]v1alpha1.ModulePhase{
 				"modelRegistry": v1alpha1.ModulePhaseDeployed,
@@ -826,7 +828,7 @@ data:
 	})
 
 	require.NoError(t, err)
-	assert.Zero(t, result.RequeueAfter)
+	assert.Equal(t, ctrlpkg.ObservabilityRetryInterval, result.RequeueAfter)
 
 	updated := &v1alpha1.Dashboard{}
 	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))

--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -25,3 +25,13 @@ func BuildFederationConfigMap(r *DashboardReconciler, statuses map[string]v1alph
 func (r *DashboardReconciler) PatchDeploymentFederationHash(ctx context.Context, configData string) error {
 	return r.patchDeploymentFederationHash(ctx, configData)
 }
+
+func (r *DashboardReconciler) AutoDetectObservability(ctx context.Context, dashboard *v1alpha1.Dashboard) error {
+	return r.autoDetectObservability(ctx, dashboard)
+}
+
+func (r *DashboardReconciler) MonitoringNamespace() string {
+	return r.monitoringNamespace()
+}
+
+const ObservabilityRetryInterval = observabilityRetryInterval

--- a/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
@@ -3,8 +3,8 @@ import { DataScienceStackComponentMap } from '@odh-dashboard/internal/concepts/a
 import { aboutDialog } from '../../../pages/aboutDialog';
 import {
   getCsvByDisplayName,
+  getDscComponentVersions,
   getInstalledProductName,
-  getResourceVersionByName,
   getSubscriptionChannelFromCsv,
   getVersionFromCsv,
 } from '../../../utils/oc_commands/applications';
@@ -16,6 +16,7 @@ const dataScienceStackComponentMap = DataScienceStackComponentMap;
 describe('Verify RHODS About Dialog', () => {
   let odhCsv: Record<string, unknown>;
   let productName: string;
+  let dscVersions: Partial<Record<string, string[]>>;
 
   retryableBefore(async () => {
     cy.log('Auto-detecting installed product (RHOAI or ODH)...');
@@ -27,6 +28,9 @@ describe('Verify RHODS About Dialog', () => {
       getCsvByDisplayName(productName, 'default').then((csv) => {
         odhCsv = csv as Record<string, unknown>;
       });
+    });
+    getDscComponentVersions().then((versions) => {
+      dscVersions = versions;
     });
   });
 
@@ -76,19 +80,18 @@ describe('Verify RHODS About Dialog', () => {
       aboutDialog.isAdminAccessLevel();
 
       aboutDialog.findTable().then(() => {
-        Object.entries(dataScienceStackComponentMap).forEach(([, component]) => {
-          cy.step(`Verify versions in About dialog's table for component: ${component}`);
-          aboutDialog.getComponentReleasesText(component).then((texts) => {
-            getResourceVersionByName(component).then((version) => {
-              if (version.length === 0) {
-                return;
-              }
-              const text = texts.join(' ');
-              expect(version.some((v) => text.includes(v))).to.equal(
-                true,
-                `Version ${version} not found for component ${component}`,
-              );
-            });
+        Object.entries(dataScienceStackComponentMap).forEach(([componentKey, displayName]) => {
+          const versions = dscVersions[componentKey];
+          if (!versions) {
+            return;
+          }
+          cy.step(`Verify versions in About dialog's table for component: ${displayName}`);
+          aboutDialog.getComponentReleasesText(displayName).then((texts) => {
+            const text = texts.join(' ');
+            expect(versions.some((v) => text.includes(v))).to.equal(
+              true,
+              `Version ${versions.join(', ')} not found for component ${displayName}`,
+            );
           });
         });
       });

--- a/packages/cypress/cypress/utils/oc_commands/applications.ts
+++ b/packages/cypress/cypress/utils/oc_commands/applications.ts
@@ -30,23 +30,50 @@ export const getOcResourceNames = (
 };
 
 /**
- * Get the version of a resource by its name.
+ * Retrieve component release versions from the DataScienceCluster status.
  *
- * @param resourceName - The name of the resource to retrieve the version for.
- * @returns A Cypress.Chainable that resolves to the version of the resource.
+ * Queries the same source the UI uses (DSC .status.components), filters out
+ * components with managementState 'Removed' and releases with version 'unknown'.
+ *
+ * @returns A map of component key to non-empty array of version strings.
  */
-export const getResourceVersionByName = (resourceName: string): Cypress.Chainable<string[]> => {
-  const ocCommand = `oc get ${resourceName.replace(
-    /\s/g,
-    '',
-  )} -A -o jsonpath='{.items[*].status.releases[*].version}'`;
+export const getDscComponentVersions = (): Cypress.Chainable<Record<string, string[]>> => {
+  const ocCommand = `oc get DataScienceCluster -A -o json`;
   return execWithOutput(ocCommand).then(({ exitCode, stdout, stderr }) => {
-    if (exitCode !== 0) {
-      cy.log(`Failed to retrieve version of ${resourceName}:\n${stdout}\n${stderr}`);
-      return cy.wrap<string[]>([]);
+    if (exitCode !== 0 || !stdout.trim()) {
+      throw new Error(
+        `Failed to retrieve DSC component versions (exit code ${exitCode}): ${stderr}`,
+      );
     }
-    cy.log(`Retrieved version of ${resourceName}:\n${stdout}\n${stderr}`);
-    return cy.wrap(stdout.trim().split(' '));
+    const dsc = JSON.parse(stdout);
+    const items: Array<{
+      status?: {
+        components?: Record<
+          string,
+          { managementState?: string; releases?: Array<{ version?: string }> }
+        >;
+      };
+    }> = dsc.items ?? [];
+    if (items.length === 0) {
+      throw new Error('No DataScienceCluster resources found on the cluster');
+    }
+    const components = items[0].status?.components ?? {};
+    const result: Record<string, string[]> = {};
+
+    Object.entries(components).forEach(([key, details]) => {
+      if (details.managementState === 'Removed') {
+        return;
+      }
+      const versions = (details.releases ?? [])
+        .map((r) => r.version)
+        .filter((v): v is string => !!v && v !== 'unknown');
+      if (versions.length > 0) {
+        result[key] = versions;
+      }
+    });
+
+    cy.log(`Retrieved DSC component versions: ${JSON.stringify(result)}`);
+    return cy.wrap(result);
   });
 };
 


### PR DESCRIPTION
## Summary

Sync `opendatahub-io/odh-dashboard:v3.5.0-fixes` into `rhoai-3.5`, bringing in 2 upstream commits:

- **e87a86fa** — fix(RHOAIENG-80354): auto-detect Perses service for observability (#9269) (#9358)
- **52317632** — fix(RHOAIENG-82728): query DSC status for About dialog version validation (#9332) (#9359)

### RHOAIENG-80354
Adds `autoDetectObservability()` to the dashboard-operator, which looks up the `data-science-perses` Service in the monitoring namespace during reconciliation. When found and `spec.observability` is nil, it populates the config in-memory (not persisted to the CR). This fixes Perses dashboards failing with "Unable to reach observability dashboards" on RHOAI deployments where `spec.observability` is never set.

### RHOAIENG-82728
Queries DSC status for About dialog version validation.

## Test plan
- [ ] Verify operator unit tests pass (`TestAutoDetectObservability`, `TestMonitoringNamespace`, `TestAutoDetectObservability_NonNotFoundError`)
- [ ] Verify About dialog version validation works correctly
- [ ] Confirm no merge conflicts with existing rhoai-3.5 content

🤖 Generated with [Claude Code](https://claude.com/claude-code)